### PR TITLE
fix #145 GHTeam.getMembers() does not page properly

### DIFF
--- a/src/main/java/org/kohsuke/github/GHTeam.java
+++ b/src/main/java/org/kohsuke/github/GHTeam.java
@@ -2,10 +2,14 @@ package org.kohsuke.github;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.TreeSet;
 
 /**
  * A team in GitHub organization.
@@ -48,12 +52,27 @@ public class GHTeam {
         return id;
     }
 
-    /**
-     * Retrieves the current members.
-     */
-    public Set<GHUser> getMembers() throws IOException {
-        return new HashSet<GHUser>(Arrays.asList(GHUser.wrap(org.root.retrieve().to(api("/members"), GHUser[].class), org.root)));
-    }
+	/**
+	 * Retrieves the current members.
+	 */
+	public Set<GHUser> getMembers() throws IOException {
+
+		Set<GHUser> members = new LinkedHashSet<GHUser>();
+		
+		Iterator<GHUser[]> pageIterator = org.root.retrieve().asIterator(api("/members"),
+				GHUser[].class);
+		while (pageIterator != null && pageIterator.hasNext()) {
+			GHUser[] users = pageIterator.next();
+			if (users != null) {
+				GHUser.wrap(users, org.root); 
+				for (GHUser user : users) {					
+					members.add(user);				
+				}
+			}
+		}
+		
+		return Collections.unmodifiableSet(members);
+	}
 
     /**
      * Checks if this team has the specified user as a member.


### PR DESCRIPTION
GHTeam.getMembers() would only return the first 30 members of an organization.  This fixes that by reading each page of results.

