### PR TITLE
Fix NullPointerException on RateLimitHandler when handling API errors.

### DIFF
--- a/src/main/java/org/kohsuke/github/GitHub.java
+++ b/src/main/java/org/kohsuke/github/GitHub.java
@@ -133,10 +133,11 @@ public class GitHub {
             }
         }
 
+        this.rateLimitHandler = rateLimitHandler;
+
         if (login==null && encodedAuthorization!=null)
             login = getMyself().getLogin();
         this.login = login;
-        this.rateLimitHandler = rateLimitHandler;
     }
 
     /**


### PR DESCRIPTION
Hello!

We encountered a NullPointerException after the upgrade to 1.67 when rate limited by the GitHub API.  Essentially it is because the call to `getMyself().getLogin()` failed during the construction of the GitHub object due to being rate limited.  However, the RateLimitHandler object had not yet been set at that point in time within the GitHub object constructor.  Fix is a simple statement movement.

Error within GitHub::handleApiError():
```
        if ("0".equals(uc.getHeaderField("X-RateLimit-Remaining"))) {
            root.rateLimitHandler.onError(e,uc);  // rateLimitHandler is null
        }
```

Ran the test suite locally after setting github authentication details:
```
Results :

Failed tests:   setLabels(org.kohsuke.github.PullRequestTest): expected:<1> but was:<0>
  setAssignee(org.kohsuke.github.PullRequestTest): expected:<User:lskillen> but was:<null>

Tests in error:
  testMembership(org.kohsuke.github.AppTest): {"message":"Must have push access to view repository collaborators.","documentation_url":"https://developer.github.com/v3"}
  testListDeployments(org.kohsuke.github.AppTest): {"message":"No ref found for: master","documentation_url":"https://developer.github.com/v3"}
  testCreateDeployment(org.kohsuke.github.AppTest): {"message":"No ref found for: master","documentation_url":"https://developer.github.com/v3"}
  testMemberPagenation(org.kohsuke.github.AppTest): java.io.IOException: {"message":"Must have admin rights to Repository.","documentation_url":"https://developer.github.com/v3"}
  testRepoLabel(org.kohsuke.github.AppTest): {"message":"Not Found","documentation_url":"https://developer.github.com/v3/issues/labels/#create-a-label"}
  testGetDeploymentStatuses(org.kohsuke.github.AppTest): {"message":"No ref found for: master","documentation_url":"https://developer.github.com/v3"}
  testCreateRepository(org.kohsuke.github.LifecycleTest): java.io.IOException: {"message":"Must have admin rights to Repository.","documentation_url":"https://developer.github.com/v3"}

Tests run: 79, Failures: 2, Errors: 7, Skipped: 10
```

Failures seem to be mostly related to access to the github-api-test-org (which obviously I don't have any permissions for), and I had the same results before/after the change so it looks like they are unrelated to it - Hopefully that's acceptable!

Thanks,
Lee