### PR TITLE
Fixes #183: added a method listForks() to GHRepository

### DIFF
--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -321,6 +321,10 @@ public class GHRepository extends GHObject {
         return fork;
     }
 
+    /**
+     * Returns the number of all forks of this repository.
+     * This not only counts direct forks, but also forks of forks, and so on.
+     */
     public int getForks() {
         return forks;
     }
@@ -511,14 +515,15 @@ public class GHRepository extends GHObject {
     public static enum Sort { NEWEST, OLDEST, STARGAZERS }
 
     /**
-     * Lists all the forks of this repository.
+     * Lists all the direct forks of this repository, sorted by {@link Sort#NEWEST Sort.NEWEST}
      */
     public PagedIterable<GHRepository> listForks() {
       return listForks(null);
     }
 
     /**
-     * Lists up all the forks of this repository, sorted by the given sort order.
+     * Lists all the direct forks of this repository, sorted by the given sort order.
+     * @param sort the sort order. If null, defaults to {@link Sort#NEWEST Sort.NEWEST}.
      */
     public PagedIterable<GHRepository> listForks(final Sort sort) {
         return new PagedIterable<GHRepository>() {

--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -506,6 +506,35 @@ public class GHRepository extends GHObject {
     }
 
     /**
+     * Sort orders for listing forks
+     */
+    public static enum Sort { NEWEST, OLDEST, STARGAZERS }
+
+    /**
+     * Lists all the forks of this repository.
+     */
+    public PagedIterable<GHRepository> listForks() {
+      return listForks(null);
+    }
+
+    /**
+     * Lists up all the forks of this repository, sorted by the given sort order.
+     */
+    public PagedIterable<GHRepository> listForks(final Sort sort) {
+        return new PagedIterable<GHRepository>() {
+            public PagedIterator<GHRepository> iterator() {
+                return new PagedIterator<GHRepository>(root.retrieve().asIterator(getApiTailUrl("forks" + ((sort == null)?"":("?sort="+sort.toString().toLowerCase(Locale.ENGLISH)))), GHRepository[].class)) {
+                    @Override
+                    protected void wrapUp(GHRepository[] page) {
+                        for (GHRepository c : page)
+                            c.wrap(root);
+                    }
+                };
+            }
+        };
+    }
+
+    /**
      * Forks this repository as your repository.
      *
      * @return

--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -37,6 +37,7 @@ import java.net.URL;
 import java.util.*;
 
 import static java.util.Arrays.asList;
+import static org.apache.commons.lang.ObjectUtils.defaultIfNull;
 
 /**
  * A repository on GitHub.
@@ -512,10 +513,11 @@ public class GHRepository extends GHObject {
     /**
      * Sort orders for listing forks
      */
-    public static enum Sort { NEWEST, OLDEST, STARGAZERS }
+    public static enum ForkSort { NEWEST, OLDEST, STARGAZERS }
 
     /**
-     * Lists all the direct forks of this repository, sorted by {@link Sort#NEWEST Sort.NEWEST}
+     * Lists all the direct forks of this repository, sorted by
+     * github api default, currently {@link ForkSort#NEWEST ForkSort.NEWEST}.
      */
     public PagedIterable<GHRepository> listForks() {
       return listForks(null);
@@ -523,16 +525,22 @@ public class GHRepository extends GHObject {
 
     /**
      * Lists all the direct forks of this repository, sorted by the given sort order.
-     * @param sort the sort order. If null, defaults to {@link Sort#NEWEST Sort.NEWEST}.
+     * @param sort the sort order. If null, defaults to github api default,
+     * currently {@link ForkSort#NEWEST ForkSort.NEWEST}.
      */
-    public PagedIterable<GHRepository> listForks(final Sort sort) {
+    public PagedIterable<GHRepository> listForks(final ForkSort sort) {
         return new PagedIterable<GHRepository>() {
             public PagedIterator<GHRepository> iterator() {
-                return new PagedIterator<GHRepository>(root.retrieve().asIterator(getApiTailUrl("forks" + ((sort == null)?"":("?sort="+sort.toString().toLowerCase(Locale.ENGLISH)))), GHRepository[].class)) {
+                String sortParam = "";
+                if (sort != null) {
+                    sortParam = "?sort=" + sort.toString().toLowerCase(Locale.ENGLISH);
+                }
+                return new PagedIterator<GHRepository>(root.retrieve().asIterator(getApiTailUrl("forks" + sortParam), GHRepository[].class)) {
                     @Override
                     protected void wrapUp(GHRepository[] page) {
-                        for (GHRepository c : page)
+                        for (GHRepository c : page) {
                             c.wrap(root);
+                        }
                     }
                 };
             }

--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -37,7 +37,6 @@ import java.net.URL;
 import java.util.*;
 
 import static java.util.Arrays.asList;
-import static org.apache.commons.lang.ObjectUtils.defaultIfNull;
 
 /**
  * A repository on GitHub.


### PR DESCRIPTION
listForks() will list all forks of a repository.

An optional sort argument is also supported.

I did not know if list* or get* is the way to go, but as getForks() is already taken (it returns the number of forks), I decided to use listForks(), with an optional sort argument.