### PR TITLE
allow default branch to be set

### DIFF
--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -494,6 +494,12 @@ public class GHRepository extends GHObject {
         edit("homepage",value);
     }
 
+    public void setMasterBranch(String value) throws IOException {
+        // This method might be more aptly named setDefaultBranch,
+        // but we'll use setMasterBranch for consistency with the existing getMasterBranch.
+        edit("default_branch", value);
+    }
+
     /**
      * Deletes this repository.
      */


### PR DESCRIPTION
GHRepository did not provide a method to set the default branch. 

Note that https://github.com/kohsuke/github-api/pull/189 is required for this to work.  