### PR TITLE
Enable creation and retrieval of org webhooks

### DIFF
--- a/src/main/java/org/kohsuke/github/GHEvent.java
+++ b/src/main/java/org/kohsuke/github/GHEvent.java
@@ -28,6 +28,7 @@ public enum GHEvent {
     PULL_REQUEST_REVIEW_COMMENT,
     PUSH,
     RELEASE,
+    REPOSITORY, // only valid for org hooks
     STATUS,
     TEAM_ADD,
     WATCH

--- a/src/main/java/org/kohsuke/github/GHHook.java
+++ b/src/main/java/org/kohsuke/github/GHHook.java
@@ -11,21 +11,11 @@ import java.util.Map;
 /**
  * @author Kohsuke Kawaguchi
  */
-public class GHHook extends GHObject {
-    /**
-     * Repository that the hook belongs to.
-     */
-    /*package*/ transient GHRepository repository;
-    
+public abstract class GHHook extends GHObject {
     String name;
     List<String> events;
     boolean active;
     Map<String,String> config;
-
-    /*package*/ GHHook wrap(GHRepository owner) {
-        this.repository = owner;
-        return this;
-    }
 
     public String getName() {
         return name;
@@ -50,7 +40,7 @@ public class GHHook extends GHObject {
      * Deletes this hook.
      */
     public void delete() throws IOException {
-        new Requester(repository.root).method("DELETE").to(String.format("/repos/%s/%s/hooks/%d", repository.getOwnerName(), repository.getName(), id));
+        new Requester(root()).method("DELETE").to(path());
     }
 
     /**
@@ -60,4 +50,8 @@ public class GHHook extends GHObject {
     public URL getHtmlUrl() {
         return null;
     }
+
+    abstract GitHub root();
+
+    abstract String path();
 }

--- a/src/main/java/org/kohsuke/github/GHHooks.java
+++ b/src/main/java/org/kohsuke/github/GHHooks.java
@@ -1,0 +1,130 @@
+package org.kohsuke.github;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Utility class for creating and retrieving webhooks; removes duplication between GHOrganization and GHRepository
+ * functionality
+ */
+class GHHooks {
+    static abstract class Context {
+        private final GitHub root;
+
+        private Context(GitHub root) {
+          this.root = root;
+        }
+
+        public List<GHHook> getHooks() throws IOException {
+            List<GHHook> list = new ArrayList<GHHook>(Arrays.asList(
+                root.retrieve().to(collection(), collectionClass())));
+            for (GHHook h : list)
+              wrap(h);
+            return list;
+        }
+
+        public GHHook getHook(int id) throws IOException {
+            GHHook hook = root.retrieve().to(collection() + "/" + id, clazz());
+            return wrap(hook);
+        }
+
+        public GHHook createHook(String name, Map<String, String> config, Collection<GHEvent> events, boolean active) throws IOException {
+            List<String> ea = null;
+            if (events!=null) {
+              ea = new ArrayList<String>();
+              for (GHEvent e : events)
+                ea.add(e.name().toLowerCase(Locale.ENGLISH));
+            }
+
+            GHHook hook = new Requester(root)
+                .with("name", name)
+                .with("active", active)
+                ._with("config", config)
+                ._with("events", ea)
+                .to(collection(), clazz());
+
+            return wrap(hook);
+        }
+
+        abstract String collection();
+
+        abstract Class<? extends GHHook[]> collectionClass();
+
+        abstract Class<? extends GHHook> clazz();
+
+        abstract GHHook wrap(GHHook hook);
+    }
+
+    private static class RepoContext extends Context {
+        private final GHRepository repository;
+        private final GHUser owner;
+
+        private RepoContext(GHRepository repository, GHUser owner) {
+            super(repository.root);
+            this.repository = repository;
+            this.owner = owner;
+        }
+
+        @Override
+        String collection() {
+            return String.format("/repos/%s/%s/hooks", owner.getLogin(), repository.getName());
+        }
+
+        @Override
+        Class<? extends GHHook[]> collectionClass() {
+            return GHRepoHook[].class;
+        }
+
+        @Override
+        Class<? extends GHHook> clazz() {
+            return GHRepoHook.class;
+        }
+
+        @Override
+        GHHook wrap(GHHook hook) {
+            return ((GHRepoHook)hook).wrap(repository);
+        }
+    }
+
+    private static class OrgContext extends Context {
+        private final GHOrganization organization;
+
+        private OrgContext(GHOrganization organization) {
+            super(organization.root);
+            this.organization = organization;
+        }
+
+        @Override
+        String collection() {
+            return String.format("/orgs/%s/hooks", organization.getLogin());
+        }
+
+        @Override
+        Class<? extends GHHook[]> collectionClass() {
+            return GHOrgHook[].class;
+        }
+
+        @Override
+        Class<? extends GHHook> clazz() {
+            return GHOrgHook.class;
+        }
+
+        @Override
+        GHHook wrap(GHHook hook) {
+            return ((GHOrgHook)hook).wrap(organization);
+        }
+    }
+
+      static Context repoContext(GHRepository repository, GHUser owner) {
+          return new RepoContext(repository, owner);
+      }
+
+      static Context orgContext(GHOrganization organization) {
+          return new OrgContext(organization);
+      }
+}

--- a/src/main/java/org/kohsuke/github/GHOrgHook.java
+++ b/src/main/java/org/kohsuke/github/GHOrgHook.java
@@ -1,0 +1,27 @@
+/*
+ * © Copyright 2015 -  SourceClear Inc
+ */
+
+package org.kohsuke.github;
+
+class GHOrgHook extends GHHook {
+    /**
+     * Organization that the hook belongs to.
+     */
+    /*package*/ transient GHOrganization organization;
+
+    /*package*/ GHOrgHook wrap(GHOrganization owner) {
+        this.organization = owner;
+        return this;
+    }
+
+    @Override
+    GitHub root() {
+        return organization.root;
+    }
+
+    @Override
+    String path() {
+        return String.format("/orgs/%s/hooks/%d", organization.getLogin(), id);
+    }
+}

--- a/src/main/java/org/kohsuke/github/GHOrganization.java
+++ b/src/main/java/org/kohsuke/github/GHOrganization.java
@@ -1,10 +1,13 @@
 package org.kohsuke.github;
 
 import java.io.IOException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -26,7 +29,7 @@ public class GHOrganization extends GHPerson {
         GHTeam t = getTeams().get(team);
         if (t==null)
             throw new IllegalArgumentException("No such team: "+team);
-        return createRepository(name,description,homepage,t,isPublic);
+        return createRepository(name, description, homepage, t, isPublic);
     }
 
     public GHRepository createRepository(String name, String description, String homepage, GHTeam team, boolean isPublic) throws IOException {
@@ -251,5 +254,40 @@ public class GHOrganization extends GHPerson {
                 };
             }
         };
+    }
+
+    /**
+     * Retrieves the currently configured hooks.
+     */
+    public List<GHHook> getHooks() throws IOException {
+        return GHHooks.orgContext(this).getHooks();
+    }
+
+    public GHHook getHook(int id) throws IOException {
+        return GHHooks.orgContext(this).getHook(id);
+    }
+
+    /**
+     *
+     * See https://api.github.com/hooks for possible names and their configuration scheme.
+     * TODO: produce type-safe binding
+     *
+     * @param name
+     *      Type of the hook to be created. See https://api.github.com/hooks for possible names.
+     * @param config
+     *      The configuration hash.
+     * @param events
+     *      Can be null. Types of events to hook into.
+     */
+    public GHHook createHook(String name, Map<String,String> config, Collection<GHEvent> events, boolean active) throws IOException {
+        return GHHooks.orgContext(this).createHook(name, config, events, active);
+    }
+
+    public GHHook createWebHook(URL url, Collection<GHEvent> events) throws IOException {
+        return createHook("web", Collections.singletonMap("url", url.toExternalForm()),events,true);
+    }
+
+    public GHHook createWebHook(URL url) throws IOException {
+        return createWebHook(url, null);
     }
 }

--- a/src/main/java/org/kohsuke/github/GHRepoHook.java
+++ b/src/main/java/org/kohsuke/github/GHRepoHook.java
@@ -1,0 +1,23 @@
+package org.kohsuke.github;
+
+class GHRepoHook extends GHHook {
+    /**
+     * Repository that the hook belongs to.
+     */
+    /*package*/ transient GHRepository repository;
+
+    /*package*/ GHRepoHook wrap(GHRepository owner) {
+        this.repository = owner;
+        return this;
+    }
+
+    @Override
+    GitHub root() {
+        return repository.root;
+    }
+
+    @Override
+    String path() {
+        return String.format("/repos/%s/%s/hooks/%d", repository.getOwnerName(), repository.getName(), id);
+    }
+}

--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -40,7 +40,7 @@ import static java.util.Arrays.asList;
 
 /**
  * A repository on GitHub.
- * 
+ *
  * @author Kohsuke Kawaguchi
  */
 @SuppressWarnings({"UnusedDeclaration"})
@@ -57,14 +57,14 @@ public class GHRepository extends GHObject {
     private int watchers,forks,open_issues,size,network_count,subscribers_count;
     private String pushed_at;
     private Map<Integer,GHMilestone> milestones = new HashMap<Integer, GHMilestone>();
-    
+
     private String default_branch,language;
     private Map<String,GHCommit> commits = new HashMap<String, GHCommit>();
 
     private GHRepoPermission permissions;
 
     private GHRepository source, parent;
-    
+
     public GHDeploymentBuilder createDeployment(String ref) {
         return new GHDeploymentBuilder(this,ref);
     }
@@ -164,7 +164,7 @@ public class GHRepository extends GHObject {
     public URL getHtmlUrl() {
         return GitHub.parseURL(html_url);
     }
-    
+
     /**
      * Short repository name without the owner. For example 'jenkins' in case of http://github.com/jenkinsci/jenkins
      */
@@ -597,15 +597,11 @@ public class GHRepository extends GHObject {
      * Retrieves the currently configured hooks.
      */
     public List<GHHook> getHooks() throws IOException {
-        List<GHHook> list = new ArrayList<GHHook>(Arrays.asList(
-                root.retrieve().to(getApiTailUrl("hooks"), GHHook[].class)));
-        for (GHHook h : list)
-            h.wrap(this);
-        return list;
+        return GHHooks.repoContext(this, owner).getHooks();
     }
 
     public GHHook getHook(int id) throws IOException {
-        return root.retrieve().to(getApiTailUrl("hooks/" + id), GHHook.class).wrap(this);
+        return GHHooks.repoContext(this, owner).getHook(id);
     }
 
     /**
@@ -649,7 +645,7 @@ public class GHRepository extends GHObject {
     }
     /**
      * Retrive a ref of the given type for the current GitHub repository.
-     * 
+     *
      * @param refName
      *            eg: heads/branch
      * @return refs matching the request type
@@ -662,7 +658,7 @@ public class GHRepository extends GHObject {
     }
     /**
      * Retrive a tree of the given type for the current GitHub repository.
-     * 
+     *
      * @param sha - sha number or branch name ex: "master"
      * @return refs matching the request type
      * @throws IOException
@@ -673,11 +669,11 @@ public class GHRepository extends GHObject {
         String url = String.format("/repos/%s/%s/git/trees/%s", owner.login, name, sha);
         return root.retrieve().to(url, GHTree.class).wrap(root);
     }
-    
+
     /**
      * Retrieves the tree for the current GitHub repository, recursively as described in here:
      * https://developer.github.com/v3/git/trees/#get-a-tree-recursively
-     * 
+     *
      * @param sha - sha number or branch name ex: "master"
      * @param recursive use 1
      * @throws IOException
@@ -774,7 +770,7 @@ public class GHRepository extends GHObject {
      * @param description
      *      Optional short description.
      *  @param context
-     *      Optinal commit status context.    
+     *      Optinal commit status context.
      */
     public GHCommitStatus createCommitStatus(String sha1, GHCommitState state, String targetUrl, String description, String context) throws IOException {
         return new Requester(root)
@@ -784,7 +780,7 @@ public class GHRepository extends GHObject {
                 .with("context", context)
                 .to(String.format("/repos/%s/%s/statuses/%s",owner.login,this.name,sha1),GHCommitStatus.class).wrapUp(root);
     }
-    
+
     /**
      *  @see #createCommitStatus(String, GHCommitState,String,String,String)
      */
@@ -858,10 +854,10 @@ public class GHRepository extends GHObject {
     }
 
     /**
-     * 
+     *
      * See https://api.github.com/hooks for possible names and their configuration scheme.
      * TODO: produce type-safe binding
-     * 
+     *
      * @param name
      *      Type of the hook to be created. See https://api.github.com/hooks for possible names.
      * @param config
@@ -870,21 +866,9 @@ public class GHRepository extends GHObject {
      *      Can be null. Types of events to hook into.
      */
     public GHHook createHook(String name, Map<String,String> config, Collection<GHEvent> events, boolean active) throws IOException {
-        List<String> ea = null;
-        if (events!=null) {
-            ea = new ArrayList<String>();
-            for (GHEvent e : events)
-                ea.add(e.name().toLowerCase(Locale.ENGLISH));
-        }
-
-        return new Requester(root)
-                .with("name", name)
-                .with("active", active)
-                ._with("config", config)
-                ._with("events",ea)
-                .to(String.format("/repos/%s/%s/hooks",owner.login,this.name),GHHook.class).wrap(this);
+        return GHHooks.repoContext(this, owner).createHook(name, config, events, active);
     }
-    
+
     public GHHook createWebHook(URL url, Collection<GHEvent> events) throws IOException {
         return createHook("web",Collections.singletonMap("url",url.toExternalForm()),events,true);
     }
@@ -909,8 +893,8 @@ public class GHRepository extends GHObject {
     /**
      * Returns a set that represents the post-commit hook URLs.
      * The returned set is live, and changes made to them are reflected to GitHub.
-     * 
-     * @deprecated 
+     *
+     * @deprecated
      *      Use {@link #getHooks()} and {@link #createHook(String, Map, Collection, boolean)}
      */
     public Set<URL> getPostCommitHooks() {
@@ -1098,19 +1082,19 @@ public class GHRepository extends GHObject {
         return new Requester(root)
                 .with("title", title).with("description", description).method("POST").to(getApiTailUrl("milestones"), GHMilestone.class).wrap(this);
     }
-    
+
     public GHDeployKey addDeployKey(String title,String key) throws IOException {
          return new Requester(root)
          .with("title", title).with("key", key).method("POST").to(getApiTailUrl("keys"), GHDeployKey.class).wrap(this);
-        
+
     }
-    
+
     public List<GHDeployKey> getDeployKeys() throws IOException{
          List<GHDeployKey> list = new ArrayList<GHDeployKey>(Arrays.asList(
                     root.retrieve().to(getApiTailUrl("keys"), GHDeployKey[].class)));
             for (GHDeployKey h : list)
                 h.wrap(this);
-            return list;    
+            return list;
     }
 
     /**
@@ -1119,7 +1103,7 @@ public class GHRepository extends GHObject {
      * @return
      *      {@link GHRepository} that points to the root repository where this repository is forked
      *      (indirectly or directly) from. Otherwise null.
-     * @see #getParent()       
+     * @see #getParent()
      */
     public GHRepository getSource() throws IOException {
         if (source == null) return null;
@@ -1136,7 +1120,7 @@ public class GHRepository extends GHObject {
      * @return
      *      {@link GHRepository} that points to the repository where this repository is forked
      *      directly from. Otherwise null.
-     * @see #getSource()      
+     * @see #getSource()
      */
     public GHRepository getParent() throws IOException {
         if (parent == null) return null;
@@ -1144,7 +1128,7 @@ public class GHRepository extends GHObject {
             parent = root.getRepository(parent.getFullName());
         return parent;
     }
-    
+
     /**
      * Subscribes to this repository to get notifications.
      */


### PR DESCRIPTION
made GHHook abstract and created two concrete subclasses for org
and repo hooks. Created utility class GHHooks to manage creation
and retrieval of org/repo hooks with minimal code duplication. These
are invoked by GHOrganization and GHRepository respectively.

Additional info on org webhooks here: https://developer.github.com/v3/orgs/hooks/

Note: requires #189 to test creation of org/repo hooks