### PR TITLE
Making Javadoc clarify a perhaps surprising behavior

### DIFF
--- a/src/main/java/org/kohsuke/github/GHOrganization.java
+++ b/src/main/java/org/kohsuke/github/GHOrganization.java
@@ -235,22 +235,20 @@ public class GHOrganization extends GHPerson {
     }
 
     /**
-     * Beware that this lists only <em>public</em> repositories.
-     * Probably you wanted to use {@link #listRepositories(int)} instead.
-     * <p>
      * {@inheritDoc}
+     * @deprecated Beware that this lists only <em>public</em> repositories. Probably you wanted to use {@link #listRepositories(int)} instead.
      */
+    @Deprecated
     @Override
     public synchronized Map<String, GHRepository> getRepositories() throws IOException {
         return super.getRepositories();
     }
 
     /**
-     * Beware that this lists only <em>public</em> repositories.
-     * Probably you wanted to use {@link #listRepositories(int)} instead.
-     * <p>
      * {@inheritDoc}
+     * @deprecated Beware that this lists only <em>public</em> repositories. Probably you wanted to use {@link #listRepositories(int)} instead.
      */
+    @Deprecated
     @Override
     public PagedIterable<GHRepository> listRepositories() {
         return super.listRepositories();
@@ -260,8 +258,6 @@ public class GHOrganization extends GHPerson {
      * Lists up all the repositories using the specified page size.
      *
      * @param pageSize size for each page of items returned by GitHub. Maximum page size is 100.
-     *
-     * Unlike {@link #getRepositories()}, this does not wait until all the repositories are returned.
      */
     @Override
     public PagedIterable<GHRepository> listRepositories(final int pageSize) {

--- a/src/main/java/org/kohsuke/github/GHOrganization.java
+++ b/src/main/java/org/kohsuke/github/GHOrganization.java
@@ -235,6 +235,28 @@ public class GHOrganization extends GHPerson {
     }
 
     /**
+     * Beware that this lists only <em>public</em> repositories.
+     * Probably you wanted to use {@link #listRepositories(int)} instead.
+     * <p>
+     * {@inheritDoc}
+     */
+    @Override
+    public synchronized Map<String, GHRepository> getRepositories() throws IOException {
+        return super.getRepositories();
+    }
+
+    /**
+     * Beware that this lists only <em>public</em> repositories.
+     * Probably you wanted to use {@link #listRepositories(int)} instead.
+     * <p>
+     * {@inheritDoc}
+     */
+    @Override
+    public PagedIterable<GHRepository> listRepositories() {
+        return super.listRepositories();
+    }
+
+    /**
      * Lists up all the repositories using the specified page size.
      *
      * @param pageSize size for each page of items returned by GitHub. Maximum page size is 100.


### PR DESCRIPTION
Was the cause of hours of confusion. Changing the behavior now might break existing clients, so just noting the better alternative.

@reviewbybees