### PR TITLE
Remove trailing slash when requesting directory content

### DIFF
--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -1094,6 +1094,9 @@ public class GHRepository extends GHObject {
 
     public List<GHContent> getDirectoryContent(String path, String ref) throws IOException {
         Requester requester = root.retrieve();
+        while (path.endsWith("/")) {
+            path = path.substring(0, path.length() - 1);
+        }
         String target = getApiTailUrl("contents/" + path);
 
         GHContent[] files = requester.with("ref",ref).to(target, GHContent[].class);

--- a/src/test/java/org/kohsuke/github/GHContentIntegrationTest.java
+++ b/src/test/java/org/kohsuke/github/GHContentIntegrationTest.java
@@ -44,6 +44,14 @@ public class GHContentIntegrationTest extends AbstractGitHubApiTestBase {
     }
 
     @Test
+    public void testGetDirectoryContentTrailingSlash() throws Exception {
+        //Used to truncate the ?ref=master, see gh-224 https://github.com/kohsuke/github-api/pull/224
+        List<GHContent> entries = repo.getDirectoryContent("ghcontent-ro/a-dir-with-3-entries/", "master");
+
+        assertTrue(entries.get(0).getUrl().endsWith("?ref=master"));
+    }
+
+    @Test
     public void testCRUDContent() throws Exception {
         GHContentUpdateResponse created = repo.createContent("this is an awesome file I created\n", "Creating a file for integration tests.", createdFilename);
         GHContent createdContent = created.getContent();


### PR DESCRIPTION
I noticed something strange on GitHub's end.

When requesting content from a directory (with a specific ref), you get [ref-specific content][1].

Now look closely what happens when you [add a trailing slash][2].

What is your view on this?


[1]: https://api.github.com/repos/github/developer.github.com/contents/lib/webhooks?ref=21295b477e6727ae09c6691e78fca7a33d28b54d
[2]: https://api.github.com/repos/github/developer.github.com/contents/lib/webhooks/?ref=21295b477e6727ae09c6691e78fca7a33d28b54d