### PR TITLE
Check builder result to either be a token or a user

### DIFF
--- a/src/main/java/org/kohsuke/github/GitHubBuilder.java
+++ b/src/main/java/org/kohsuke/github/GitHubBuilder.java
@@ -51,7 +51,7 @@ public class GitHubBuilder {
         try {
             builder = fromPropertyFile();
 
-            if (builder.user != null)
+            if (builder.oauthToken != null || builder.user != null)
                 return builder;
         } catch (FileNotFoundException e) {
             // fall through
@@ -60,7 +60,7 @@ public class GitHubBuilder {
 
         builder = fromEnvironment();
 
-        if (builder.user != null)
+        if (builder.oauthToken != null || builder.user != null)
             return builder;
         else
             throw (IOException)new IOException("Failed to resolve credentials from ~/.github or the environment.").initCause(cause);


### PR DESCRIPTION
Currently, a `user` property is always required (it not having content is also fine).

This adds support for only having the `oauth` key in the property file/environment.