### PR TITLE
Use default timeouts for URLConnections

### DIFF
--- a/src/main/java/org/kohsuke/github/GitHubBuilder.java
+++ b/src/main/java/org/kohsuke/github/GitHubBuilder.java
@@ -186,7 +186,10 @@ public class GitHubBuilder {
     public GitHubBuilder withProxy(final Proxy p) {
         return withConnector(new HttpConnector() {
             public HttpURLConnection connect(URL url) throws IOException {
-                return (HttpURLConnection) url.openConnection(p);
+                HttpURLConnection con = (HttpURLConnection) url.openConnection(p);
+                con.setConnectTimeout(HttpConnector.HTTP_CONNECT_TIMEOUT);
+                con.setReadTimeout(HttpConnector.HTTP_READ_TIMEOUT);
+                return con;
             }
         });
     }

--- a/src/main/java/org/kohsuke/github/HttpConnector.java
+++ b/src/main/java/org/kohsuke/github/HttpConnector.java
@@ -3,6 +3,7 @@ package org.kohsuke.github;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Pluggability for customizing HTTP request behaviors or using altogether different library.
@@ -23,7 +24,13 @@ public interface HttpConnector {
      */
     HttpConnector DEFAULT = new HttpConnector() {
         public HttpURLConnection connect(URL url) throws IOException {
-            return (HttpURLConnection) url.openConnection();
+            HttpURLConnection con = (HttpURLConnection) url.openConnection();
+            con.setConnectTimeout(HTTP_CONNECT_TIMEOUT);
+            con.setReadTimeout(HTTP_READ_TIMEOUT);
+            return con;
         }
     };
+
+    int HTTP_CONNECT_TIMEOUT = (int) TimeUnit.SECONDS.toMillis(10);
+    int HTTP_READ_TIMEOUT = (int) TimeUnit.SECONDS.toMillis(10);
 }


### PR DESCRIPTION
[JENKINS-31827](https://issues.jenkins-ci.org/browse/JENKINS-31827)

I suggest to fix it in github-api so all clients will be reasonably safe and it seems like the best place to maintain reasonable defaults for the service.