### PR TITLE
Fix error when creating email service hook

### DIFF
--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -475,7 +475,7 @@ public class GHRepository extends GHObject {
     public void setEmailServiceHook(String address) throws IOException {
         Map<String, String> config = new HashMap<String, String>();
         config.put("address", address);
-        new Requester(root).method("POST").with("name", "email").with("config", config).with("active", "true")
+        new Requester(root).method("POST").with("name", "email").with("config", config).with("active", true)
                 .to(getApiTailUrl("hooks"));
     }
 


### PR DESCRIPTION
The Jenkins IRC bot started throwing 

`{"message":"Invalid request.\n\nFor 'properties/active', \"true\" is not a boolean.","documentation_url":"https://developer.github.com/v3/repos/hooks/#create-a-hook"}`

Untested.