### PR TITLE
Animal sniffer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,27 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>animal-sniffer-maven-plugin</artifactId>
+        <version>1.15</version>
+        <configuration>
+          <signature>
+            <groupId>org.codehaus.mojo.signature</groupId>
+            <artifactId>java15</artifactId>
+            <version>1.0</version>
+          </signature>
+        </configuration>
+        <executions>
+          <execution>
+            <id>ensure-java-1.5-class-library</id>
+            <phase>test</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>com.infradna.tool</groupId>
         <artifactId>bridge-method-injector</artifactId>
         <version>1.14</version>

--- a/src/main/java/org/kohsuke/github/GHCompare.java
+++ b/src/main/java/org/kohsuke/github/GHCompare.java
@@ -4,8 +4,6 @@ import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.net.URL;
-import java.util.Arrays;
-import java.util.Date;
 
 /**
  * The model user for comparing 2 commits in the GitHub API.
@@ -72,7 +70,9 @@ public class GHCompare {
      * @return A copy of the array being stored in the class.
      */
     public Commit[] getCommits() {
-        return Arrays.copyOf(commits, commits.length);
+        Commit[] newValue = new Commit[commits.length];
+        System.arraycopy(commits, 0, newValue, 0, commits.length);
+        return newValue;
     }
     
     /**
@@ -80,7 +80,9 @@ public class GHCompare {
      * @return A copy of the array being stored in the class.
      */
     public GHCommit.File[] getFiles() {
-        return Arrays.copyOf(files, files.length);
+        GHCommit.File[] newValue = new GHCommit.File[files.length];
+        System.arraycopy(files, 0, newValue, 0, files.length);
+        return newValue;
     }
 
     public GHCompare wrap(GHRepository owner) {

--- a/src/main/java/org/kohsuke/github/GHPullRequestCommitDetail.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequestCommitDetail.java
@@ -27,7 +27,6 @@ import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.net.URL;
-import java.util.Arrays;
 
 /**
  * Commit detail inside a {@link GHPullRequest}.
@@ -144,6 +143,8 @@ public class GHPullRequestCommitDetail {
     }
 
     public CommitPointer[] getParents() {
-        return Arrays.copyOf(parents, parents.length);
+        CommitPointer[] newValue = new CommitPointer[parents.length];
+        System.arraycopy(parents, 0, newValue, 0, parents.length);
+        return newValue;
     }
 }

--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -1152,7 +1152,7 @@ public class GHRepository extends GHObject {
         try {
             payload = content.getBytes("UTF-8");
         } catch (UnsupportedEncodingException ex) {
-            throw  new IOException("UTF-8 encoding is not supported", ex);
+            throw (IOException) new IOException("UTF-8 encoding is not supported").initCause(ex);
         }
         return createContent(payload, commitMessage, path, branch);
     }

--- a/src/main/java/org/kohsuke/github/GitHub.java
+++ b/src/main/java/org/kohsuke/github/GitHub.java
@@ -48,7 +48,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.codec.Charsets;
 import org.apache.commons.codec.binary.Base64;
@@ -264,7 +263,8 @@ public class GitHub {
             // see issue #78
             GHRateLimit r = new GHRateLimit();
             r.limit = r.remaining = 1000000;
-            r.reset = new Date(System.currentTimeMillis() + TimeUnit.HOURS.toMillis(1));
+            long hours = 1000L * 60 * 60;
+            r.reset = new Date(System.currentTimeMillis() + 1 * hours );
             return r;
         }
     }

--- a/src/main/java/org/kohsuke/github/GitHub.java
+++ b/src/main/java/org/kohsuke/github/GitHub.java
@@ -57,7 +57,6 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.introspect.VisibilityChecker.Std;
 import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
-import java.nio.charset.Charset;
 import java.util.logging.Logger;
 
 /**
@@ -134,8 +133,8 @@ public class GitHub {
         } else {
             if (password!=null) {
                 String authorization = (login + ':' + password);
-                Charset charset = Charsets.UTF_8;
-                encodedAuthorization = "Basic "+new String(Base64.encodeBase64(authorization.getBytes(charset)), charset);
+                String charsetName = Charsets.UTF_8.name();
+                encodedAuthorization = "Basic "+new String(Base64.encodeBase64(authorization.getBytes(charsetName)), charsetName);
             } else {// anonymous access
                 encodedAuthorization = null;
             }


### PR DESCRIPTION
Hello @kohsuke.

Seeing as you recently set the compiler target back to 5, I wanted to help you maintain this compatibility.
There is still one unresolved issue:
```
--- animal-sniffer-maven-plugin:1.15:check (ensure-java-1.5-class-library) @ github-api ---
Checking unresolved references to org.codehaus.mojo.signature:java15:1.0
X:\Git\github\github-api\src\main\java\org\kohsuke\github\GHContent.java:81: Undefined reference: byte[] javax.xml.bind.DatatypeConverter.parseBase64Binary(String)
X:\Git\github\github-api\src\main\java\org\kohsuke\github\GHContent.java:182: Undefined reference: String javax.xml.bind.DatatypeConverter.printBase64Binary(byte[])
X:\Git\github\github-api\src\main\java\org\kohsuke\github\GHRepository.java:1165: Undefined reference: String javax.xml.bind.DatatypeConverter.printBase64Binary(byte[])
```

Hope that you can integrate this.