### PR TITLE
'uploadAsset()' method call for Github Enterprise

### DIFF
--- a/src/main/java/org/kohsuke/github/GHRelease.java
+++ b/src/main/java/org/kohsuke/github/GHRelease.java
@@ -124,7 +124,7 @@ public class GHRelease extends GHObject {
      *
      * @param file file to upload
      * @param contentType content type
-     * @param uploadUrlPrefix ULR prefix for uploading; for example, for github.com it's https://uploads.github.com
+     * @param uploadUrlPrefix URL prefix for uploading; for example, for github.com it's https://uploads.github.com
      * @return instance of GHAsset uploaded
      * @since 1.75
      * @throws IOException

--- a/src/main/java/org/kohsuke/github/GHRelease.java
+++ b/src/main/java/org/kohsuke/github/GHRelease.java
@@ -9,6 +9,7 @@ import java.util.Date;
 import java.util.List;
 
 import static java.lang.String.format;
+import static org.apache.commons.lang.ObjectUtils.defaultIfNull;
 
 /**
  * Release in a github repository.
@@ -128,7 +129,7 @@ public class GHRelease extends GHObject {
      *
      * @param file file to upload
      * @param contentType content type
-     * @param uploadUrlPrefix URL prefix for uploading; for example, for github.com it's https://uploads.github.com
+     * @param uploadUrlPrefix URL prefix for uploading; if null {@link #DEFAULT_UPLOAD_URL} will be used
      * @return instance of GHAsset uploaded
      * @since 1.75
      * @throws IOException
@@ -137,7 +138,7 @@ public class GHRelease extends GHObject {
         Requester builder = new Requester(owner.root);
 
         String url = format("%s%s/releases/%d/assets?name=%s",
-                            uploadUrlPrefix, owner.getApiTailUrl(""), getId(), file.getName());
+                            defaultIfNull(uploadUrlPrefix, DEFAULT_UPLOAD_URL), owner.getApiTailUrl(""), getId(), file.getName());
         return builder.contentType(contentType)
                 .with(new FileInputStream(file))
                 .to(url, GHAsset.class).wrap(this);

--- a/src/main/java/org/kohsuke/github/GHRelease.java
+++ b/src/main/java/org/kohsuke/github/GHRelease.java
@@ -19,9 +19,6 @@ import static org.apache.commons.lang.ObjectUtils.defaultIfNull;
  */
 public class GHRelease extends GHObject {
 
-    /** github.com's default upload URL */
-    public final static String DEFAULT_UPLOAD_URL = "https://uploads.github.com";
-
     GitHub root;
     GHRepository owner;
 

--- a/src/main/java/org/kohsuke/github/GHRelease.java
+++ b/src/main/java/org/kohsuke/github/GHRelease.java
@@ -122,6 +122,8 @@ public class GHRelease extends GHObject {
     }
 
     /**
+     * upload the release using upload URL in {@link upload_url} field.
+     *
      * Because github relies on SNI (http://en.wikipedia.org/wiki/Server_Name_Indication) this method will only work on
      * Java 7 or greater.  Options for fixing this for earlier JVMs can be found here
      * http://stackoverflow.com/questions/12361090/server-name-indication-sni-on-java but involve more complicated
@@ -129,33 +131,18 @@ public class GHRelease extends GHObject {
      *
      * @param file file to upload
      * @param contentType content type
-     * @param uploadUrlPrefix URL prefix for uploading; if null {@link #DEFAULT_UPLOAD_URL} will be used
-     * @return instance of GHAsset uploaded
-     * @since 1.75
-     * @throws IOException
-     */
-    public GHAsset uploadAsset(File file, String contentType, String uploadUrlPrefix) throws IOException {
-        Requester builder = new Requester(owner.root);
-
-        String url = format("%s%s/releases/%d/assets?name=%s",
-                            defaultIfNull(uploadUrlPrefix, DEFAULT_UPLOAD_URL), owner.getApiTailUrl(""), getId(), file.getName());
-        return builder.contentType(contentType)
-                .with(new FileInputStream(file))
-                .to(url, GHAsset.class).wrap(this);
-    }
-
-    /**
-     * upload the release to defaul upload URL on github.com
-     *
-     * @param file file to upload
-     * @param contentType content type
      * @return instance of GHAsset uploaded
      * @throws IOException
      */
     public GHAsset uploadAsset(File file, String contentType) throws IOException {
-        return this.uploadAsset(file, contentType, DEFAULT_UPLOAD_URL);
-    }
+        Requester builder = new Requester(owner.root);
 
+        String url = format(upload_url.replace("{?name}", "?name=%s"), file.getName());
+
+        return builder.contentType(contentType)
+                .with(new FileInputStream(file))
+                .to(url, GHAsset.class).wrap(this);
+    }
 
     public List<GHAsset> getAssets() throws IOException {
         Requester builder = new Requester(owner.root);

--- a/src/main/java/org/kohsuke/github/GHRelease.java
+++ b/src/main/java/org/kohsuke/github/GHRelease.java
@@ -125,6 +125,8 @@ public class GHRelease extends GHObject {
      * @param file file to upload
      * @param contentType content type
      * @param uploadUrlPrefix ULR prefix for uploading; for example, for github.com it's https://uploads.github.com
+     * @return instance of GHAsset uploaded
+     * @since 1.75
      * @throws IOException
      */
     public GHAsset uploadAsset(File file, String contentType, String uploadUrlPrefix) throws IOException {
@@ -142,6 +144,7 @@ public class GHRelease extends GHObject {
      *
      * @param file file to upload
      * @param contentType content type
+     * @return instance of GHAsset uploaded
      * @throws IOException
      */
     public GHAsset uploadAsset(File file, String contentType) throws IOException {

--- a/src/main/java/org/kohsuke/github/GHRelease.java
+++ b/src/main/java/org/kohsuke/github/GHRelease.java
@@ -122,17 +122,32 @@ public class GHRelease extends GHObject {
      * http://stackoverflow.com/questions/12361090/server-name-indication-sni-on-java but involve more complicated
      * handling of the HTTP requests to github's API.
      *
+     * @param file file to upload
+     * @param contentType content type
+     * @param uploadUrlPrefix ULR prefix for uploading; for example, for github.com it's https://uploads.github.com
      * @throws IOException
      */
-    public GHAsset uploadAsset(File file, String contentType) throws IOException {
+    public GHAsset uploadAsset(File file, String contentType, String uploadUrlPrefix) throws IOException {
         Requester builder = new Requester(owner.root);
 
-        String url = format("https://uploads.github.com%s/releases/%d/assets?name=%s",
-                owner.getApiTailUrl(""), getId(), file.getName());
+        String url = format("%s%s/releases/%d/assets?name=%s",
+                            uploadUrlPrefix, owner.getApiTailUrl(""), getId(), file.getName());
         return builder.contentType(contentType)
                 .with(new FileInputStream(file))
                 .to(url, GHAsset.class).wrap(this);
     }
+
+    /**
+     * upload the release to defaul upload URL on github.com
+     *
+     * @param file file to upload
+     * @param contentType content type
+     * @throws IOException
+     */
+    public GHAsset uploadAsset(File file, String contentType) throws IOException {
+        return this.uploadAsset(file, contentType, "https://uploads.github.com");
+    }
+
 
     public List<GHAsset> getAssets() throws IOException {
         Requester builder = new Requester(owner.root);

--- a/src/main/java/org/kohsuke/github/GHRelease.java
+++ b/src/main/java/org/kohsuke/github/GHRelease.java
@@ -17,6 +17,10 @@ import static java.lang.String.format;
  * @see GHRepository#createRelease(String)
  */
 public class GHRelease extends GHObject {
+
+    /** github.com's default upload URL */
+    public final static String DEFAULT_UPLOAD_URL = "https://uploads.github.com";
+
     GitHub root;
     GHRepository owner;
 
@@ -148,7 +152,7 @@ public class GHRelease extends GHObject {
      * @throws IOException
      */
     public GHAsset uploadAsset(File file, String contentType) throws IOException {
-        return this.uploadAsset(file, contentType, "https://uploads.github.com");
+        return this.uploadAsset(file, contentType, DEFAULT_UPLOAD_URL);
     }
 
 


### PR DESCRIPTION
I am not sure if it is possible to 'ask' the GitHub API for the default
upload URL; that would be great but if not, we need to pass it somehow.

refs #266
