### PR TITLE
Added support for the extended stargazers API in Github V3 API

### DIFF
--- a/src/main/java/org/kohsuke/github/GHStargazer.java
+++ b/src/main/java/org/kohsuke/github/GHStargazer.java
@@ -1,0 +1,48 @@
+package org.kohsuke.github;
+
+import java.util.Date;
+
+/**
+ * A stargazer at a repository on GitHub.
+ *
+ * @author noctarius
+ */
+public class GHStargazer {
+
+    private GHRepository repository;
+    private String starred_at;
+    private GHUser user;
+
+    /**
+     * Gets the repository that is stargazed
+     *
+     * @return the starred repository
+     */
+    public GHRepository getRepository() {
+        return repository;
+    }
+
+    /**
+     * Gets the date when the repository was starred, however old stars before
+     * August 2012, will all show the date the API was changed to support starred_at.
+     *
+     * @return the date the stargazer was added
+     */
+    public Date getStarredAt() {
+        return GitHub.parseDate(starred_at);
+    }
+
+    /**
+     * Gets the user that starred the repository
+     *
+     * @return the stargazer user
+     */
+    public GHUser getUser() {
+        return user;
+    }
+
+    void wrapUp(GHRepository repository) {
+        this.repository = repository;
+        user.wrapUp(repository.root);
+    }
+}


### PR DESCRIPTION
Github has added starred_at date to stargazers when stargazers are requested with a special (new) version on the REST API. Added support for the version and a type representing the additional information.