### PR TITLE
Add Slug to GHTeam per v3 API: https://developer.github.com/v3/orgs/t…

### DIFF
--- a/src/main/java/org/kohsuke/github/GHOrganization.java
+++ b/src/main/java/org/kohsuke/github/GHOrganization.java
@@ -94,6 +94,17 @@ public class GHOrganization extends GHPerson {
     }
 
     /**
+     * Finds a team that has the given slug in its {@link GHTeam#getSlug()}
+     */
+    public GHTeam getTeamBySlug(String slug) throws IOException {
+        for (GHTeam t : listTeams()) {
+            if(t.getSlug().equals(slug))
+                return t;
+        }
+        return null;
+    }
+
+    /**
      * Checks if this organization has the specified user as a member.
      */
     public boolean hasMember(GHUser user) {

--- a/src/main/java/org/kohsuke/github/GHTeam.java
+++ b/src/main/java/org/kohsuke/github/GHTeam.java
@@ -12,7 +12,7 @@ import java.util.TreeMap;
  * @author Kohsuke Kawaguchi
  */
 public class GHTeam {
-    private String name,permission;
+    private String name,permission,slug;
     private int id;
     private GHOrganization organization; // populated by GET /user/teams where Teams+Orgs are returned together
 
@@ -41,6 +41,10 @@ public class GHTeam {
 
     public String getPermission() {
         return permission;
+    }
+
+    public String getSlug() {
+        return slug;
     }
 
     public int getId() {

--- a/src/test/java/org/kohsuke/github/AppTest.java
+++ b/src/test/java/org/kohsuke/github/AppTest.java
@@ -336,6 +336,13 @@ public class AppTest extends AbstractGitHubApiTestBase {
     }
 
     @Test
+    public void testOrgTeamBySlug() throws Exception {
+        kohsuke();
+        GHTeam e = gitHub.getOrganization("github-api-test-org").getTeamBySlug("core-developers");
+        assertNotNull(e);
+    }
+
+    @Test
     public void testCommit() throws Exception {
         GHCommit commit = gitHub.getUser("jenkinsci").getRepository("jenkins").getCommit("08c1c9970af4d609ae754fbe803e06186e3206f7");
         System.out.println(commit);


### PR DESCRIPTION
https://developer.github.com/v3/orgs/teams/ has a slug property for teams. This property is similar to the login property for users and organizations - a URL path friendly tokenized string (as opposed to free text in the name field). 

Slug is better suited for use in automated / scripting cases when dealing with the Team API.

Admittedly, I wrote a test but could not test as the project's test harness requires super powers which I do not possess.

@reviewbybees