### PR TITLE
related to JENKINS-34834. updating test for similar condition

### DIFF
--- a/src/test/java/org/kohsuke/github/AppTest.java
+++ b/src/test/java/org/kohsuke/github/AppTest.java
@@ -221,10 +221,12 @@ public class AppTest extends AbstractGitHubApiTestBase {
     }
 
     @Test
-    public void testMyTeamsContainsAllMyOrganizations() throws IOException {
+    public void testMyOrganizationsContainMyTeams() throws IOException {
         Map<String, Set<GHTeam>> teams = gitHub.getMyTeams();
         Map<String, GHOrganization> myOrganizations = gitHub.getMyOrganizations();
-        assertEquals(teams.keySet(), myOrganizations.keySet());
+        //GitHub no longer has default 'owners' team, so there may be organization memberships without a team
+        //https://help.github.com/articles/about-improved-organization-permissions/
+        assertTrue(myOrganizations.keySet().containsAll(teams.keySet()));
     }
     
     @Test


### PR DESCRIPTION
Since GitHub no longer creates a default team per organization (ie: no more default 'Owners' team), this test needs to be updated. 