### PR TITLE
Implement an abuse handler

### DIFF
--- a/src/main/java/org/kohsuke/github/GitHub.java
+++ b/src/main/java/org/kohsuke/github/GitHub.java
@@ -83,6 +83,7 @@ public class GitHub {
     private final String apiUrl;
 
     /*package*/ final RateLimitHandler rateLimitHandler;
+    /*package*/ final RateLimitHandler abuseLimitHandler;
 
     private HttpConnector connector = HttpConnector.DEFAULT;
 
@@ -122,7 +123,7 @@ public class GitHub {
      * @param connector
      *      HttpConnector to use. Pass null to use default connector.
      */
-    /* package */ GitHub(String apiUrl, String login, String oauthAccessToken, String password, HttpConnector connector, RateLimitHandler rateLimitHandler) throws IOException {
+    /* package */ GitHub(String apiUrl, String login, String oauthAccessToken, String password, HttpConnector connector, RateLimitHandler rateLimitHandler, RateLimitHandler abuseLimitHandler) throws IOException {
         if (apiUrl.endsWith("/")) apiUrl = apiUrl.substring(0, apiUrl.length()-1); // normalize
         this.apiUrl = apiUrl;
         if (null != connector) this.connector = connector;
@@ -140,6 +141,7 @@ public class GitHub {
         }
 
         this.rateLimitHandler = rateLimitHandler;
+        this.abuseLimitHandler = abuseLimitHandler;
 
         if (login==null && encodedAuthorization!=null)
             login = getMyself().getLogin();

--- a/src/main/java/org/kohsuke/github/GitHubBuilder.java
+++ b/src/main/java/org/kohsuke/github/GitHubBuilder.java
@@ -30,6 +30,7 @@ public class GitHubBuilder {
     private HttpConnector connector;
 
     private RateLimitHandler rateLimitHandler = RateLimitHandler.WAIT;
+    private RateLimitHandler abuseLimitHandler = RateLimitHandler.ABUSE;
 
     public GitHubBuilder() {
     }
@@ -193,6 +194,6 @@ public class GitHubBuilder {
     }
 
     public GitHub build() throws IOException {
-        return new GitHub(endpoint, user, oauthToken, password, connector, rateLimitHandler);
+        return new GitHub(endpoint, user, oauthToken, password, connector, rateLimitHandler, abuseLimitHandler);
     }
 }

--- a/src/main/java/org/kohsuke/github/Requester.java
+++ b/src/main/java/org/kohsuke/github/Requester.java
@@ -572,6 +572,14 @@ class Requester {
             root.rateLimitHandler.onError(e,uc);
             return;
         }
+        
+        // Check to see whether we hit a 403, and the Retry-After field is
+        // available.
+        if (responseCode == HttpURLConnection.HTTP_FORBIDDEN && 
+            uc.getHeaderField("Retry-After") != null) {
+            this.root.abuseLimitHandler.onError(e,uc);
+            return;
+        }
 
         InputStream es = wrapStream(uc.getErrorStream());
         try {


### PR DESCRIPTION
If too many requests are made within X amount of time (not the traditional hourly rate limit), github may begin returning 403.  Then we should wait for a bit to attempt to access the API again.  In this case, we parse out the Retry-After field returned and sleep until that (it's usually 60 seconds)

Fixes #285 