### PR TITLE
url encode hashes in ref names

### DIFF
--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -765,6 +765,8 @@ public class GHRepository extends GHObject {
      *             invalid ref type being requested
      */
     public GHRef getRef(String refName) throws IOException {
+        // hashes in branch names must be replaced with the url encoded equivalent or this call will fail
+        refName = refName.replaceAll("#", "%23");
         return root.retrieve().to(String.format("/repos/%s/%s/git/refs/%s", owner.login, name, refName), GHRef.class).wrap(root);
     }
     /**


### PR DESCRIPTION
Without this fix, the following code:

```
GHRepository repo = gh.getRepository("iown/test");
String branch = "heads/bsheats/#107-test-branch";
ref = repo.getRef(branch);
```

will fail with this exception:

```
Exception in thread "main" org.kohsuke.github.HttpException: Server returned HTTP response code: 200, message: 'OK' for URL: https://api.github.com/repos/iown/test/git/refs/heads/bsheats/#107-test-branch
	at org.kohsuke.github.Requester.parse(Requester.java:540)
	at org.kohsuke.github.Requester._to(Requester.java:251)
	at org.kohsuke.github.Requester.to(Requester.java:213)
	at org.kohsuke.github.GHRepository.getRef(GHRepository.java:770)
	at Foo.main(Foo.java:22)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.intellij.rt.execution.application.AppMain.main(AppMain.java:147)
Caused by: java.io.IOException: Failed to deserialize [{"ref":"refs/heads/bsheats/test","url":"https://api.github.com/repos/iown/test/git/refs/heads/bsheats/test","object":{"sha":"7c4a0777bdbd76442ee98e54daee808a5ca0e211","type":"commit","url":"https://api.github.com/repos/iown/test/git/commits/7c4a0777bdbd76442ee98e54daee808a5ca0e211"}},{"ref":"refs/heads/bsheats/#107-test-branch","url":"https://api.github.com/repos/iown/test/git/refs/heads/bsheats/%23107-test-branch","object":{"sha":"fca609f46dbbee95170e8a1dc283329ea1c768f6","type":"commit","url":"https://api.github.com/repos/iown/test/git/commits/fca609f46dbbee95170e8a1dc283329ea1c768f6"}}]
	at org.kohsuke.github.Requester.parse(Requester.java:530)
	... 9 more
Caused by: com.fasterxml.jackson.databind.JsonMappingException: Can not deserialize instance of org.kohsuke.github.GHRef out of START_ARRAY token
 at [Source: java.io.StringReader@e50a6f6; line: 1, column: 1]
	at com.fasterxml.jackson.databind.JsonMappingException.from(JsonMappingException.java:164)
	at com.fasterxml.jackson.databind.DeserializationContext.mappingException(DeserializationContext.java:575)
	at com.fasterxml.jackson.databind.DeserializationContext.mappingException(DeserializationContext.java:569)
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.deserializeFromArray(BeanDeserializerBase.java:1121)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer._deserializeOther(BeanDeserializer.java:148)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:123)
	at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:2888)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:2034)
	at org.kohsuke.github.Requester.parse(Requester.java:528)
	... 9 more
```



