### PR TITLE
Fix fields of GHRepository

### DIFF
--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -75,10 +75,10 @@ public class GHRepository extends GHObject {
 
     private String git_url, ssh_url, clone_url, svn_url, mirror_url;
     private GHUser owner;   // not fully populated. beware.
-    private boolean has_issues, has_wiki, fork, has_downloads;
+    private boolean has_issues, has_wiki, fork, has_downloads, has_pages;
     @JsonProperty("private")
     private boolean _private;
-    private int watchers,forks,open_issues,size,network_count,subscribers_count;
+    private int forks_count, stargazers_count, watchers_count, size, open_issues_count, subscribers_count;
     private String pushed_at;
     private Map<Integer,GHMilestone> milestones = new HashMap<Integer, GHMilestone>();
 
@@ -358,8 +358,12 @@ public class GHRepository extends GHObject {
      * Returns the number of all forks of this repository.
      * This not only counts direct forks, but also forks of forks, and so on.
      */
-    public int getForks() {
-        return forks;
+    public int getForksCount() {
+        return forks_count;
+    }
+
+    public int getStargazersCount() {
+        return stargazers_count;
     }
 
     public boolean isPrivate() {
@@ -370,16 +374,16 @@ public class GHRepository extends GHObject {
         return has_downloads;
     }
 
-    public int getWatchers() {
-        return watchers;
+    public boolean hasPages() {
+        return has_pages;
+    }
+
+    public int getWatchersCount() {
+        return watchers_count;
     }
 
     public int getOpenIssueCount() {
-        return open_issues;
-    }
-
-    public int getNetworkCount() {
-        return network_count;
+        return open_issues_count;
     }
 
     public int getSubscribersCount() {


### PR DESCRIPTION
According to the lasted version of [https://developer.github.com/v3/repos/#get](https://developer.github.com/v3/repos/#get) , the fields of GHRepository need be fixed:

- Add new field `has_pages` ;
- Add new field `stargazers_count`, **Be careful, Pull request #301 did the same thing**
- Rename `forks` to `forks_count`,  `forks` still works, but you can't see it in the newest docs;
- Rename `watchers` to `watchers_count`,  `watchers` still works, but you can't see it in the newest docs;
- Rename `open_issues` to `open_issues_count`,  `open_issues` still works, but you can't see it in the newest docs;
- Delete `network_count`, I am not sure what it means, but it is always same as forks_count, and of coursed you can't see it in the newest docs;

I did some basic tests, this is the result:

```
kohsuke/github-api:
hasPages:true
getForksCount:241
getStargazersCount:307
getWatchersCount:307
getOpenIssueCount:17
```

You may notice that the `watchers_count` is same as `stargazers_count`, it is not a bug in my code, you can see the same situation in the docs, and the `subscribers_count` is the real watcher count.