### PR TITLE
Fix typos in javadocs

### DIFF
--- a/src/main/java/org/kohsuke/github/GHPerson.java
+++ b/src/main/java/org/kohsuke/github/GHPerson.java
@@ -93,10 +93,10 @@ public abstract class GHPerson extends GHObject {
     }
 
     /**
-     * Loads repository list in a pagenated fashion.
+     * Loads repository list in a paginated fashion.
      * 
      * <p>
-     * For a person with a lot of repositories, GitHub returns the list of repositories in a pagenated fashion.
+     * For a person with a lot of repositories, GitHub returns the list of repositories in a paginated fashion.
      * Unlike {@link #getRepositories()}, this method allows the caller to start processing data as it arrives.
      * 
      * Every {@link Iterator#next()} call results in I/O. Exceptions that occur during the processing is wrapped

--- a/src/main/java/org/kohsuke/github/PagedIterator.java
+++ b/src/main/java/org/kohsuke/github/PagedIterator.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 
 /**
- * Iterator over a pagenated data source.
+ * Iterator over a paginated data source.
  *
  * Aside from the normal iterator operation, this method exposes {@link #nextPage()}
  * that allows the caller to retrieve items per page.

--- a/src/main/java/org/kohsuke/github/Requester.java
+++ b/src/main/java/org/kohsuke/github/Requester.java
@@ -355,7 +355,7 @@ class Requester {
     }
 
     /**
-     * Loads pagenated resources.
+     * Loads paginated resources.
      *
      * Every iterator call reports a new batch.
      */


### PR DESCRIPTION
Replace "pagenated" with "paginated".