### PR TITLE
Expose Rate Limit Headers

### DIFF
--- a/src/main/java/org/kohsuke/github/GitHub.java
+++ b/src/main/java/org/kohsuke/github/GitHub.java
@@ -259,6 +259,10 @@ public class GitHub {
         return connector;
     }
 
+    public String getApiUrl() {
+        return apiUrl;
+    }
+
     /**
      * Sets the custom connector used to make requests to GitHub.
      */


### PR DESCRIPTION
Exposes the rate limit header responses so that consumers of the API can proactively tune their usage.

@reviewbybees