### PR TITLE
Fix a bug in the Javadocs (due to copy and paste)

### DIFF
--- a/src/main/java/org/kohsuke/github/GHPullRequest.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequest.java
@@ -208,7 +208,7 @@ public class GHPullRequest extends GHIssue {
     }
 
     /**
-     * Retrieves all the commits associated to this pull request.
+     * Retrieves all the files associated to this pull request.
      */
     public PagedIterable<GHPullRequestFileDetail> listFiles() {
         return new PagedIterable<GHPullRequestFileDetail>() {


### PR DESCRIPTION
I found a typo in the Javadocs (looks like the comment has been copied along with the method but has not been updated after the method itself has been adapted)