### PR TITLE
Add application/json header when sending json data.

### DIFF
--- a/src/main/java/org/kohsuke/github/Requester.java
+++ b/src/main/java/org/kohsuke/github/Requester.java
@@ -385,15 +385,16 @@ class Requester {
     private void buildRequest() throws IOException {
         if (isMethodWithBody()) {
             uc.setDoOutput(true);
-            uc.setRequestProperty("Content-type", contentType);
 
             if (body == null) {
+                uc.setRequestProperty("Content-type", "application/json");
                 Map json = new HashMap();
                 for (Entry e : args) {
                     json.put(e.key, e.value);
                 }
                 MAPPER.writeValue(uc.getOutputStream(), json);
             } else {
+                uc.setRequestProperty("Content-type", contentType);
                 try {
                     byte[] bytes = new byte[32768];
                     int read = 0;


### PR DESCRIPTION
I'm using Jenkins and SonarQube GitHub plugins with [GitBucket](https://github.com/gitbucket/gitbucket).
GitBucket has GitHub-compatible API.
But it is not 100% compatible. This PR solves one of the differences between GitHub and GitBucket. And, it also solves header and body data format mismatch when sending json data.

in current version's Requester.java [buildRequest](https://github.com/kohsuke/github-api/blob/2627dc5ee4ed60c0250ce5a9e99d586d480603f2/src/main/java/org/kohsuke/github/Requester.java#L385) sends json data with content-type: application/x-www-form-urlencoded.
This behavior is incorrect. data and header mismatch. Then, GitBucket was confused by how to handle data.

In GitHub API, GitHub parses this data as json (header content-type is ignored), but this behavior is not documented. In the future this behavior may change.

I think that it is better to accept this modification to avoid future problems.