### PR TITLE
Add the Commit search API

### DIFF
--- a/src/main/java/org/kohsuke/github/GHCommitSearchBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHCommitSearchBuilder.java
@@ -1,0 +1,115 @@
+package org.kohsuke.github;
+
+import java.util.Locale;
+
+/**
+ * Search commits.
+ *
+ * @author Marc de Verdelhan
+ * @see GitHub#searchCommits()
+ */
+@Preview @Deprecated
+public class GHCommitSearchBuilder extends GHSearchBuilder<GHCommit> {
+    /*package*/ GHCommitSearchBuilder(GitHub root) {
+        super(root,CommitSearchResult.class);
+        req = req.withPreview(Previews.CLOAK);
+    }
+
+    /**
+     * Search terms.
+     */
+    public GHCommitSearchBuilder q(String term) {
+        super.q(term);
+        return this;
+    }
+
+    public GHCommitSearchBuilder author(String v) {
+        return q("author:"+v);
+    }
+
+    public GHCommitSearchBuilder committer(String v) {
+        return q("committer:"+v);
+    }
+
+    public GHCommitSearchBuilder authorName(String v) {
+        return q("author-name:"+v);
+    }
+
+    public GHCommitSearchBuilder committerName(String v) {
+        return q("committer-name:"+v);
+    }
+
+    public GHCommitSearchBuilder authorEmail(String v) {
+        return q("author-email:"+v);
+    }
+
+    public GHCommitSearchBuilder committerEmail(String v) {
+        return q("committer-email:"+v);
+    }
+
+    public GHCommitSearchBuilder authorDate(String v) {
+        return q("author-date:"+v);
+    }
+
+    public GHCommitSearchBuilder committerDate(String v) {
+        return q("committer-date:"+v);
+    }
+
+    public GHCommitSearchBuilder merge(boolean merge) {
+        return q("merge:"+Boolean.valueOf(merge).toString().toLowerCase());
+    }
+
+    public GHCommitSearchBuilder hash(String v) {
+        return q("hash:"+v);
+    }
+
+    public GHCommitSearchBuilder parent(String v) {
+        return q("parent:"+v);
+    }
+
+    public GHCommitSearchBuilder tree(String v) {
+        return q("tree:"+v);
+    }
+
+    public GHCommitSearchBuilder is(String v) {
+        return q("is:"+v);
+    }
+
+    public GHCommitSearchBuilder user(String v) {
+        return q("user:"+v);
+    }
+
+    public GHCommitSearchBuilder org(String v) {
+        return q("org:"+v);
+    }
+
+    public GHCommitSearchBuilder repo(String v) {
+        return q("repo:"+v);
+    }
+
+    public GHCommitSearchBuilder order(GHDirection v) {
+        req.with("order",v);
+        return this;
+    }
+
+    public GHCommitSearchBuilder sort(Sort sort) {
+        req.with("sort",sort);
+        return this;
+    }
+
+    public enum Sort { AUTHOR_DATE, COMMITTER_DATE }
+
+    private static class CommitSearchResult extends SearchResult<GHCommit> {
+        private GHCommit[] items;
+
+        @Override
+        /*package*/ GHCommit[] getItems(GitHub root) {
+            return items;
+        }
+    }
+
+    @Override
+    protected String getApiUrl() {
+        return "/search/commits";
+    }
+}

--- a/src/main/java/org/kohsuke/github/GHCommitSearchBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHCommitSearchBuilder.java
@@ -1,6 +1,9 @@
 package org.kohsuke.github;
 
+import java.io.IOException;
 import java.util.Locale;
+
+import org.apache.commons.lang.StringUtils;
 
 /**
  * Search commits.
@@ -104,8 +107,28 @@ public class GHCommitSearchBuilder extends GHSearchBuilder<GHCommit> {
 
         @Override
         /*package*/ GHCommit[] getItems(GitHub root) {
+            for (GHCommit commit : items) {
+                String repoName = getRepoName(commit.url);
+                try {
+                    GHRepository repo = root.getRepository(repoName);
+                    commit.wrapUp(repo);
+                } catch (IOException ioe) {}
+            }
             return items;
         }
+    }
+    
+    /**
+     * @param commitUrl a commit URL
+     * @return the repo name ("username/reponame")
+     */
+    private static String getRepoName(String commitUrl) {
+        if (StringUtils.isBlank(commitUrl)) {
+            return null;
+        }
+        int indexOfUsername = (GitHub.GITHUB_URL + "/repos/").length();
+        String[] tokens = commitUrl.substring(indexOfUsername).split("/", 3);
+        return tokens[0] + '/' + tokens[1];
     }
 
     @Override

--- a/src/main/java/org/kohsuke/github/GHQueryBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHQueryBuilder.java
@@ -7,7 +7,7 @@ package org.kohsuke.github;
  */
 public abstract class GHQueryBuilder<T> {
     protected final GitHub root;
-    protected final Requester req;
+    protected Requester req;
 
     /*package*/ GHQueryBuilder(GitHub root) {
         this.root = root;

--- a/src/main/java/org/kohsuke/github/GitHub.java
+++ b/src/main/java/org/kohsuke/github/GitHub.java
@@ -720,6 +720,14 @@ public class GitHub {
     }
 
     /**
+     * Search commits.
+     */
+    @Preview @Deprecated
+    public GHCommitSearchBuilder searchCommits() {
+        return new GHCommitSearchBuilder(this);
+    }
+
+    /**
      * Search issues.
      */
     public GHIssueSearchBuilder searchIssues() {

--- a/src/main/java/org/kohsuke/github/Previews.java
+++ b/src/main/java/org/kohsuke/github/Previews.java
@@ -8,4 +8,5 @@ package org.kohsuke.github;
     static final String DRAX = "application/vnd.github.drax-preview+json";
     static final String SQUIRREL_GIRL = "application/vnd.github.squirrel-girl-preview";
     static final String KORRA = "application/vnd.github.korra-preview";
+    static final String CLOAK = "application/vnd.github.cloak-preview";
 }

--- a/src/test/java/org/kohsuke/github/AppTest.java
+++ b/src/test/java/org/kohsuke/github/AppTest.java
@@ -689,6 +689,9 @@ public class AppTest extends AbstractGitHubApiTestBase {
     public void testCommitSearch() throws IOException {
         PagedSearchIterable<GHCommit> r = gitHub.searchCommits().author("kohsuke").list();
         assertTrue(r.getTotalCount() > 0);
+        
+        GHCommit firstCommit = r.iterator().next();
+        assertTrue(firstCommit.getFiles().size() > 0);
     }
 
     @Test

--- a/src/test/java/org/kohsuke/github/AppTest.java
+++ b/src/test/java/org/kohsuke/github/AppTest.java
@@ -686,6 +686,12 @@ public class AppTest extends AbstractGitHubApiTestBase {
     }
 
     @Test
+    public void testCommitSearch() throws IOException {
+        PagedSearchIterable<GHCommit> r = gitHub.searchCommits().author("kohsuke").list();
+        assertTrue(r.getTotalCount() > 0);
+    }
+
+    @Test
     public void testIssueSearch() throws IOException {
         PagedSearchIterable<GHIssue> r = gitHub.searchIssues().mentions("kohsuke").isOpen().list();
         for (GHIssue i : r) {


### PR DESCRIPTION
Fix #345 - Add the Commit search API (still in preview in GitHub API v3)

See also: https://developer.github.com/v3/search/#search-commits