### PR TITLE
[JENKINS-36240] /repos/:owner/:repo/collaborators/:username/permission no longer requires korra preview

### DIFF
--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -486,9 +486,8 @@ public class GHRepository extends GHObject {
      * @throws FileNotFoundException under some conditions (e.g., private repo you can see but are not an admin of); treat as unknown
      * @throws HttpException with a 403 under other conditions (e.g., public repo you have no special rights to); treat as unknown
      */
-    @Deprecated @Preview
     public GHPermissionType getPermission(String user) throws IOException {
-        GHPermission perm = root.retrieve().withPreview(KORRA).to(getApiTailUrl("collaborators/" + user + "/permission"), GHPermission.class);
+        GHPermission perm = root.retrieve().to(getApiTailUrl("collaborators/" + user + "/permission"), GHPermission.class);
         perm.wrapUp(root);
         return perm.getPermissionType();
     }
@@ -498,7 +497,6 @@ public class GHRepository extends GHObject {
      * @throws FileNotFoundException under some conditions (e.g., private repo you can see but are not an admin of); treat as unknown
      * @throws HttpException with a 403 under other conditions (e.g., public repo you have no special rights to); treat as unknown
      */
-    @Deprecated @Preview
     public GHPermissionType getPermission(GHUser u) throws IOException {
         return getPermission(u.getLogin());
     }

--- a/src/main/java/org/kohsuke/github/Previews.java
+++ b/src/main/java/org/kohsuke/github/Previews.java
@@ -7,5 +7,4 @@ package org.kohsuke.github;
     static final String LOKI = "application/vnd.github.loki-preview+json";
     static final String DRAX = "application/vnd.github.drax-preview+json";
     static final String SQUIRREL_GIRL = "application/vnd.github.squirrel-girl-preview";
-    static final String KORRA = "application/vnd.github.korra-preview";
 }


### PR DESCRIPTION
[JENKINS-36240](https://issues.jenkins-ci.org/browse/JENKINS-36240)

Amends #324 (and its unfiled follow-ups). [This API](https://developer.github.com/v3/repos/collaborators/#review-a-users-permission-level) seems to now be official.

@reviewbybees esp. @stephenc & @kohsuke