### PR TITLE
bridge-method-annotation should be an optional dep

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,7 @@
       <groupId>com.infradna.tool</groupId>
       <artifactId>bridge-method-annotation</artifactId>
       <version>1.14</version>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.kohsuke.stapler</groupId>


### PR DESCRIPTION
b6e48cc4f9c7b13895673a7b4aa6399b7e236b1f introduced a hard dep on a lib which is newer than that currently bundled in core, causing problems for `requireUpperBoundDeps`.

@reviewbybees