### PR TITLE
Add support for pr review/review comment events

### DIFF
--- a/src/main/java/org/kohsuke/github/GHEventPayload.java
+++ b/src/main/java/org/kohsuke/github/GHEventPayload.java
@@ -85,6 +85,95 @@ public abstract class GHEventPayload {
         }
     }
 
+
+    /**
+     * A review was added to a pull request
+     *
+     * @see <a href="https://developer.github.com/v3/activity/events/types/#pullrequestreviewevent">authoritative source</a>
+     */
+    public static class PullRequestReview extends GHEventPayload {
+        private String action;
+        private GHPullRequestReview review;
+        private GHPullRequest pull_request;
+        private GHRepository repository;
+
+        public String getAction() {
+            return action;
+        }
+        
+        public GHPullRequestReview getReview() {
+            return review;
+        }
+
+        public GHPullRequest getPullRequest() {
+            return pull_request;
+        }
+
+        public GHRepository getRepository() {
+            return repository;
+        }
+
+        @Override
+        void wrapUp(GitHub root) {
+            super.wrapUp(root);
+            if (review==null)
+                throw new IllegalStateException("Expected pull_request_review payload, but got something else. Maybe we've got another type of event?");
+            
+            review.wrapUp(pull_request);
+            
+            if (repository!=null) {
+                repository.wrap(root);
+                pull_request.wrapUp(repository);
+            } else {
+                pull_request.wrapUp(root);
+            }
+        }
+    }
+    
+    /**
+     * A review comment was added to a pull request
+     *
+     * @see <a href="https://developer.github.com/v3/activity/events/types/#pullrequestreviewcommentevent">authoritative source</a>
+     */
+    public static class PullRequestReviewComment extends GHEventPayload {
+        private String action;
+        private GHPullRequestReviewComment comment;
+        private GHPullRequest pull_request;
+        private GHRepository repository;
+
+        public String getAction() {
+            return action;
+        }
+        
+        public GHPullRequestReviewComment getComment() {
+            return comment;
+        }
+
+        public GHPullRequest getPullRequest() {
+            return pull_request;
+        }
+
+        public GHRepository getRepository() {
+            return repository;
+        }
+
+        @Override
+        void wrapUp(GitHub root) {
+            super.wrapUp(root);
+            if (comment==null)
+                throw new IllegalStateException("Expected pull_request_review_comment payload, but got something else. Maybe we've got another type of event?");
+            
+            comment.wrapUp(pull_request);
+            
+            if (repository!=null) {
+                repository.wrap(root);
+                pull_request.wrapUp(repository);
+            } else {
+                pull_request.wrapUp(root);
+            }
+        }
+    }
+
     /**
      * A comment was added to an issue
      *

--- a/src/main/java/org/kohsuke/github/GHPullRequestReview.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequestReview.java
@@ -40,7 +40,7 @@ public class GHPullRequestReview extends GHObject {
     private String body;
     private GHUser user;
     private String commit_id;
-    private GHPullRequestReviewState state;
+    private String state;
 
     /*package*/ GHPullRequestReview wrapUp(GHPullRequest owner) {
         this.owner = owner;
@@ -73,7 +73,7 @@ public class GHPullRequestReview extends GHObject {
     }
 
     public GHPullRequestReviewState getState() {
-        return state;
+        return GHPullRequestReviewState.valueOf(state.toUpperCase());
     }
 
     @Override
@@ -97,7 +97,7 @@ public class GHPullRequestReview extends GHObject {
                 .withPreview("application/vnd.github.black-cat-preview+json")
                 .to(getApiRoute()+"/events",this);
         this.body = body;
-        this.state = event;
+        this.state = event.name();
     }
 
     /**
@@ -121,7 +121,7 @@ public class GHPullRequestReview extends GHObject {
                 .with("message", message)
                 .withPreview(BLACK_CAT)
                 .to(getApiRoute()+"/dismissals");
-        state = GHPullRequestReviewState.DISMISSED;
+        state = GHPullRequestReviewState.DISMISSED.name();
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHPullRequestReviewState.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequestReviewState.java
@@ -3,7 +3,7 @@ package org.kohsuke.github;
 public enum GHPullRequestReviewState {
     PENDING(null),
     APPROVED("APPROVE"),
-    REQUEST_CHANGES("REQUEST_CHANGES"),
+    CHANGES_REQUESTED("REQUEST_CHANGES"),
     COMMENTED("COMMENT"),
     DISMISSED(null);
 

--- a/src/test/java/org/kohsuke/github/GHEventPayloadTest.java
+++ b/src/test/java/org/kohsuke/github/GHEventPayloadTest.java
@@ -187,13 +187,61 @@ public class GHEventPayloadTest {
         assertThat(event.getSender().getLogin(), is("baxterthehacker"));
     }
 
-// TODO implement support classes and write test
-//    @Test
-//    public void pull_request_review() throws Exception {}
+    @Test
+    public void pull_request_review() throws Exception {
+        GHEventPayload.PullRequestReview event =
+                GitHub.offline().parseEventPayload(payload.asReader(), GHEventPayload.PullRequestReview.class);
+        assertThat(event.getAction(), is("submitted"));
+        
+        assertThat(event.getReview().getId(), is(2626884));
+        assertThat(event.getReview().getBody(), is("Looks great!"));
+        assertThat(event.getReview().getState(), is(GHPullRequestReviewState.APPROVED));
+        
+        assertThat(event.getPullRequest().getNumber(), is(8));
+        assertThat(event.getPullRequest().getTitle(), is("Add a README description"));
+        assertThat(event.getPullRequest().getBody(), is("Just a few more details"));
+        assertThat(event.getPullRequest().getUser().getLogin(), is("skalnik"));
+        assertThat(event.getPullRequest().getHead().getUser().getLogin(), is("skalnik"));
+        assertThat(event.getPullRequest().getHead().getRef(), is("patch-2"));
+        assertThat(event.getPullRequest().getHead().getLabel(), is("skalnik:patch-2"));
+        assertThat(event.getPullRequest().getHead().getSha(), is("b7a1f9c27caa4e03c14a88feb56e2d4f7500aa63"));
+        assertThat(event.getPullRequest().getBase().getUser().getLogin(), is("baxterthehacker"));
+        assertThat(event.getPullRequest().getBase().getRef(), is("master"));
+        assertThat(event.getPullRequest().getBase().getLabel(), is("baxterthehacker:master"));
+        assertThat(event.getPullRequest().getBase().getSha(), is("9049f1265b7d61be4a8904a9a27120d2064dab3b"));
+        
+        assertThat(event.getRepository().getName(), is("public-repo"));
+        assertThat(event.getRepository().getOwner().getLogin(), is("baxterthehacker"));
+        
+        assertThat(event.getSender().getLogin(), is("baxterthehacker"));
+    }
 
-// TODO implement support classes and write test
-//    @Test
-//    public void pull_request_review_comment() throws Exception {}
+    @Test
+    public void pull_request_review_comment() throws Exception {
+        GHEventPayload.PullRequestReviewComment event =
+                GitHub.offline().parseEventPayload(payload.asReader(), GHEventPayload.PullRequestReviewComment.class);
+        assertThat(event.getAction(), is("created"));
+        
+        assertThat(event.getComment().getBody(), is("Maybe you should use more emojji on this line."));
+        
+        assertThat(event.getPullRequest().getNumber(), is(1));
+        assertThat(event.getPullRequest().getTitle(), is("Update the README with new information"));
+        assertThat(event.getPullRequest().getBody(), is("This is a pretty simple change that we need to pull into master."));
+        assertThat(event.getPullRequest().getUser().getLogin(), is("baxterthehacker"));
+        assertThat(event.getPullRequest().getHead().getUser().getLogin(), is("baxterthehacker"));
+        assertThat(event.getPullRequest().getHead().getRef(), is("changes"));
+        assertThat(event.getPullRequest().getHead().getLabel(), is("baxterthehacker:changes"));
+        assertThat(event.getPullRequest().getHead().getSha(), is("0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c"));
+        assertThat(event.getPullRequest().getBase().getUser().getLogin(), is("baxterthehacker"));
+        assertThat(event.getPullRequest().getBase().getRef(), is("master"));
+        assertThat(event.getPullRequest().getBase().getLabel(), is("baxterthehacker:master"));
+        assertThat(event.getPullRequest().getBase().getSha(), is("9049f1265b7d61be4a8904a9a27120d2064dab3b"));
+        
+        assertThat(event.getRepository().getName(), is("public-repo"));
+        assertThat(event.getRepository().getOwner().getLogin(), is("baxterthehacker"));
+        
+        assertThat(event.getSender().getLogin(), is("baxterthehacker"));
+    }
 
     @Test
     public void push() throws Exception {


### PR DESCRIPTION
Add support for pr review/review comment events building on #352 

There was one non-passive change with `GHPullRequestReviewState` the enum value did not match the value returned from the github API. I verified this on github.com and an enterprise instance.