### PR TITLE
Addressing issue #348. This will allow skipping to a page number for

### DIFF
--- a/src/main/java/org/kohsuke/github/GHCommitQueryBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHCommitQueryBuilder.java
@@ -57,6 +57,12 @@ public class GHCommitQueryBuilder {
         return this;
     }
 
+    public GHCommitQueryBuilder page(int startPage) {
+    	if(startPage>1)
+    		req.with("page",startPage);
+        return this;
+    }
+    
     /**
      * Only commits after this date will be returned
      */

--- a/src/main/java/org/kohsuke/github/GHIssueSearchBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHIssueSearchBuilder.java
@@ -49,6 +49,12 @@ public class GHIssueSearchBuilder extends GHSearchBuilder<GHIssue> {
         return this;
     }
 
+    public GHIssueSearchBuilder page(int startPage) {
+    	if(startPage>1)
+    		req.with("page",startPage);
+        return this;
+    }
+
     public enum Sort { COMMENTS, CREATED, UPDATED }
 
     private static class IssueSearchResult extends SearchResult<GHIssue> {

--- a/src/main/java/org/kohsuke/github/GHRepositorySearchBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHRepositorySearchBuilder.java
@@ -23,6 +23,10 @@ public class GHRepositorySearchBuilder extends GHSearchBuilder<GHRepository> {
         return q("in:"+v);
     }
 
+    public GHRepositorySearchBuilder topic(String v) {
+        return q("topic:"+v);
+    }
+
     public GHRepositorySearchBuilder size(String v) {
         return q("size:"+v);
     }
@@ -62,6 +66,12 @@ public class GHRepositorySearchBuilder extends GHSearchBuilder<GHRepository> {
 
     public GHRepositorySearchBuilder sort(Sort sort) {
         req.with("sort",sort);
+        return this;
+    }
+
+    public GHRepositorySearchBuilder page(int startPage) {
+    	if(startPage>1)
+    		req.with("page",startPage);
         return this;
     }
 

--- a/src/main/java/org/kohsuke/github/GHUserSearchBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHUserSearchBuilder.java
@@ -57,6 +57,12 @@ public class GHUserSearchBuilder extends GHSearchBuilder<GHUser> {
         return this;
     }
 
+    public GHUserSearchBuilder page(int startPage) {
+    	if(startPage>1)
+    		req.with("page",startPage);
+        return this;
+    }
+
     public enum Sort { FOLLOWERS, REPOSITORIES, JOINED }
 
     private static class UserSearchResult extends SearchResult<GHUser> {


### PR DESCRIPTION
the all the search builders . The alternative is to implement it at the page
PagedIterable level which will require changes throughout all the
classes that reference it. Since this is primarily a search issue this
solution might suffice.

Also added support for the repository search parameter "topic"