### PR TITLE
Fixed OAuth connection to enterprise API

### DIFF
--- a/src/main/java/org/kohsuke/github/GitHub.java
+++ b/src/main/java/org/kohsuke/github/GitHub.java
@@ -178,6 +178,10 @@ public class GitHub {
         return new GitHubBuilder().withEndpoint(apiUrl).withOAuthToken(oauthAccessToken).build();
     }
 
+    public static GitHub connectToEnterpriseWtihOAuth(String apiUrl, String login, String oauthAccessToken) throws IOException {
+        return new GitHubBuilder().withEndpoint(apiUrl).withOAuthToken(oauthAccessToken, login).build();
+    }
+
     public static GitHub connectToEnterprise(String apiUrl, String login, String password) throws IOException {
         return new GitHubBuilder().withEndpoint(apiUrl).withPassword(login, password).build();
     }

--- a/src/main/java/org/kohsuke/github/GitHub.java
+++ b/src/main/java/org/kohsuke/github/GitHub.java
@@ -178,7 +178,7 @@ public class GitHub {
         return new GitHubBuilder().withEndpoint(apiUrl).withOAuthToken(oauthAccessToken).build();
     }
 
-    public static GitHub connectToEnterpriseWtihOAuth(String apiUrl, String login, String oauthAccessToken) throws IOException {
+    public static GitHub connectToEnterpriseWithOAuth(String apiUrl, String login, String oauthAccessToken) throws IOException {
         return new GitHubBuilder().withEndpoint(apiUrl).withOAuthToken(oauthAccessToken, login).build();
     }
 


### PR DESCRIPTION
I see that the change to OAuth was made a long time ago. I just started using this library at work, and we use GitHub Enterprise. 

When connecting with OAuth, I was getting a failure on the connection when using `GitHub.connectToEnterprise(apiUrl, oauthAccessToken)` I noticed that there was no option to use login. I thought this was strange and tried to get to the bottom of it. 

The reason I have proposed the fix in this way was so that I didn't break the existing functionality (I don't think it was functioning as intended, but if it has gone this long without fixing I have to assume it is working for someone). That is why I didn't touch the existing method.

I am new to this project, so if there is more that I need to do for this to meet your requirements, please let me know.