### PR TITLE
Labels: add method to update color

### DIFF
--- a/src/main/java/org/kohsuke/github/GHLabel.java
+++ b/src/main/java/org/kohsuke/github/GHLabel.java
@@ -34,4 +34,8 @@ public class GHLabel {
     public void delete() throws IOException {
         repo.root.retrieve().method("DELETE").to(url);
     }
+
+    public void updateColor(String newColor) throws IOException {
+        repo.root.retrieve().method("PATCH").with("name", name).with("color", newColor).to(url);
+    }
 }

--- a/src/test/java/org/kohsuke/github/AppTest.java
+++ b/src/test/java/org/kohsuke/github/AppTest.java
@@ -753,6 +753,10 @@ public class AppTest extends AbstractGitHubApiTestBase {
             assertEquals(t.getColor(), "123456");
             assertEquals(t.getColor(), t2.getColor());
             assertEquals(t.getUrl(), t2.getUrl());
+
+            t.updateColor("000000");
+            GHLabel t3 = r.getLabel("test");
+            assertEquals(t3.getColor(), "000000");
             t.delete();
         }
     }


### PR DESCRIPTION
Currently impossible to update a label, this PR adds this support.

@kohsuke 