### PR TITLE
Add get for all organizations

### DIFF
--- a/src/main/java/org/kohsuke/github/GitHub.java
+++ b/src/main/java/org/kohsuke/github/GitHub.java
@@ -424,6 +424,9 @@ public class GitHub {
         return u;
     }
 
+    /**
+     * Gets {@link GHOrganization} specified by name.
+     */
     public GHOrganization getOrganization(String name) throws IOException {
         GHOrganization o = orgs.get(name);
         if (o==null) {
@@ -431,6 +434,35 @@ public class GitHub {
             orgs.put(name,o);
         }
         return o;
+    }
+
+    /**
+     * Gets a list of all organizations.
+     */
+    public PagedIterable<GHOrganization> getOrganizations() {
+        return getOrganizations(null);
+    }
+
+    /**
+     * Gets a list of all organizations starting after the organization identifier specified by 'since'.
+     *
+     * @see <a href="https://developer.github.com/v3/orgs/#parameters">List All Orgs - Parameters</a>
+     */
+    public PagedIterable<GHOrganization> getOrganizations(final String since) {
+        return new PagedIterable<GHOrganization>() {
+            @Override
+            public PagedIterator<GHOrganization> _iterator(int pageSize) {
+                System.out.println("page size: " + pageSize);
+                return new PagedIterator<GHOrganization>(retrieve().with("since",since)
+                        .asIterator("/organizations", GHOrganization[].class, pageSize)) {
+                    @Override
+                    protected void wrapUp(GHOrganization[] page) {
+                        for (GHOrganization c : page)
+                            c.wrapUp(GitHub.this);
+                    }
+                };
+            }
+        };
     }
 
     /**

--- a/src/test/java/org/kohsuke/github/GitHubTest.java
+++ b/src/test/java/org/kohsuke/github/GitHubTest.java
@@ -3,13 +3,12 @@ package org.kohsuke.github;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 import com.google.common.collect.Iterables;
 import org.junit.Test;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -154,5 +153,17 @@ public class GitHubTest {
             assert u.getName()!=null;
             System.out.println(u.getName());
         }
+    }
+
+    @Test
+    public void getOrgs() throws IOException {
+        GitHub hub = GitHub.connect();
+        int iterations = 10;
+        Set<Long> orgIds = new HashSet<Long>();
+        for (GHOrganization org : Iterables.limit(hub.getOrganizations().withPageSize(2), iterations)) {
+            orgIds.add(org.getId());
+            System.out.println(org.getName());
+        }
+        assertThat(orgIds.size(), equalTo(iterations));
     }
 }

--- a/src/test/java/org/kohsuke/github/GitHubTest.java
+++ b/src/test/java/org/kohsuke/github/GitHubTest.java
@@ -3,7 +3,11 @@ package org.kohsuke.github;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 import com.google.common.collect.Iterables;
 import org.junit.Test;


### PR DESCRIPTION
Add support for fetching all organizations using the [`/organizations`](https://developer.github.com/v3/orgs/#list-all-organizations) endpoint. Supports paging and allows for the page size to be specified.