### PR TITLE
Populate the GHPullRequest if 'mergeable' is null

### DIFF
--- a/src/main/java/org/kohsuke/github/GHPullRequest.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequest.java
@@ -216,7 +216,7 @@ public class GHPullRequest extends GHIssue {
      * Depending on the original API call where this object is created, it may not contain everything.
      */
     private void populate() throws IOException {
-        if (mergeable_state!=null)    return; // already populated
+        if (mergeable_state!=null && mergeable!=null)    return; // already populated
         if (root.isOffline()) {
             return; // cannot populate, will have to live with what we have
         }


### PR DESCRIPTION
GitHub sometimes returns a response which has the 'mergeable_state' set
to 'unknown' (ant thus non-null) and the 'mergable' is 'null'. 'isMergable()'
then returns 'null' instead of 'boolean'. This can to unexpected issues for
the caller.

I am by far not sure that this is a good approach. It can definitely lead to more API calls, which may not be desired. Please let me know if you see a better alternative for this.