### PR TITLE
Improved Pull Request review and comments support

### DIFF
--- a/src/main/java/org/kohsuke/github/GHPullRequest.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequest.java
@@ -23,7 +23,6 @@
  */
 package org.kohsuke.github;
 
-import javax.annotation.CheckForNull;
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -298,23 +297,19 @@ public class GHPullRequest extends GHIssue {
 
     @Preview
     @Deprecated
-    public GHPullRequestReview createReview(String body, @CheckForNull GHPullRequestReviewState event,
-                                            GHPullRequestReviewComment... comments)
+    public GHPullRequestReview createReview(String body, GHPullRequestReviewComment... comments)
             throws IOException {
-        return createReview(body, event, Arrays.asList(comments));
+        return createReview(body, Arrays.asList(comments));
     }
 
     @Preview
     @Deprecated
-    public GHPullRequestReview createReview(String body, @CheckForNull GHPullRequestReviewState event,
-                                            List<GHPullRequestReviewComment> comments)
+    public GHPullRequestReview createReview(String body, List<GHPullRequestReviewComment> comments)
             throws IOException {
-//        if (event == null) {
-//            event = GHPullRequestReviewState.PENDING;
-//        }
         List<DraftReviewComment> draftComments = new ArrayList<DraftReviewComment>(comments.size());
         for (GHPullRequestReviewComment c : comments) {
-            draftComments.add(new DraftReviewComment(c.getBody(), c.getPath(), c.getPosition()));
+            Integer position = c.getPosition();
+            draftComments.add(new DraftReviewComment(c.getBody(), c.getPath(), position == null ? 0 : position /*FIXME do not use GHPullRequestReviewComment for new comments*/));
         }
         return new Requester(root).method("POST")
                 .with("body", body)

--- a/src/main/java/org/kohsuke/github/GHPullRequest.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequest.java
@@ -90,7 +90,7 @@ public class GHPullRequest extends GHIssue {
     public URL getPatchUrl() {
         return GitHub.parseURL(patch_url);
     }
-    
+
     /**
      * The URL of the patch file.
      * like https://github.com/jenkinsci/jenkins/pull/100.patch
@@ -113,7 +113,7 @@ public class GHPullRequest extends GHIssue {
     public GHCommitPointer getHead() {
         return head;
     }
-    
+
     @Deprecated
     public Date getIssueUpdatedAt() throws IOException {
         return super.getUpdatedAt();
@@ -326,6 +326,17 @@ public class GHPullRequest extends GHIssue {
                 .with("path", path)
                 .with("position", position)
                 .to(getApiRoute() + "/comments", GHPullRequestReviewComment.class).wrapUp(this);
+    }
+
+    /**
+     * Create a reply to the current comment.
+     */
+    public GHPullRequestReviewComment createReviewCommentReply(GHPullRequestReviewComment comment, String body) throws IOException {
+        return new Requester(owner.root).method("POST")
+                .with("body", body)
+                .with("in_reply_to", comment.getId())
+                .to(getApiRoute() + "/comments", GHPullRequestReviewComment.class)
+                .wrapUp(this);
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHPullRequestReview.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequestReview.java
@@ -25,6 +25,7 @@ package org.kohsuke.github;
 
 import java.io.IOException;
 import java.net.URL;
+import javax.annotation.CheckForNull;
 
 import static org.kohsuke.github.Previews.*;
 
@@ -32,7 +33,7 @@ import static org.kohsuke.github.Previews.*;
  * Review to the pull request
  *
  * @see GHPullRequest#listReviews()
- * @see GHPullRequest#createReview(String, GHPullRequestReviewState, GHPullRequestReviewComment...)
+ * @see GHPullRequest#createReview(String, GHPullRequestReviewComment...)
  */
 public class GHPullRequestReview extends GHObject {
     GHPullRequest owner;
@@ -72,6 +73,7 @@ public class GHPullRequestReview extends GHObject {
         return commit_id;
     }
 
+    @CheckForNull
     public GHPullRequestReviewState getState() {
         return state;
     }
@@ -90,14 +92,13 @@ public class GHPullRequestReview extends GHObject {
      */
     @Preview
     @Deprecated
-    public void submit(String body, GHPullRequestReviewState event) throws IOException {
+    public void submit(String body, GHPullRequestReviewEvent event) throws IOException {
         new Requester(owner.root).method("POST")
                 .with("body", body)
                 .with("event", event.action())
                 .withPreview("application/vnd.github.black-cat-preview+json")
                 .to(getApiRoute()+"/events",this);
         this.body = body;
-        this.state = event;
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHPullRequestReviewAbstract.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequestReviewAbstract.java
@@ -1,0 +1,101 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2011, Eric Maupin
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.kohsuke.github;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import java.io.IOException;
+import java.net.URL;
+
+@SuppressFBWarnings(value = {"UWF_UNWRITTEN_FIELD"}, justification = "JSON API")
+public abstract class GHPullRequestReviewAbstract extends GHObject {
+    protected GHPullRequest owner;
+
+    protected String body;
+    private GHUser user;
+    private String commit_id;
+
+    public abstract GHPullRequestReviewState getState();
+
+    /**
+     * Gets the pull request to which this review is associated.
+     */
+    public GHPullRequest getParent() {
+        return owner;
+    }
+
+    /**
+     * The comment itself.
+     */
+    public String getBody() {
+        return body;
+    }
+
+    /**
+     * Gets the user who posted this review.
+     */
+    public GHUser getUser() throws IOException {
+        return owner.root.getUser(user.getLogin());
+    }
+
+    public String getCommitId() {
+        return commit_id;
+    }
+
+    @Override
+    public URL getHtmlUrl() {
+        return null;
+    }
+
+    String getApiRoute() {
+        return owner.getApiRoute() + "/reviews/" + id;
+    }
+
+    /**
+     * Deletes this review.
+     */
+    public void delete() throws IOException {
+        new Requester(owner.root).method("DELETE")
+                .to(getApiRoute());
+    }
+
+    /**
+     * Obtains all the review comments associated with this pull request review.
+     */
+    public PagedIterable<GHPullRequestReviewComment> listReviewComments() {
+        return new PagedIterable<GHPullRequestReviewComment>() {
+            public PagedIterator<GHPullRequestReviewComment> _iterator(int pageSize) {
+                return new PagedIterator<GHPullRequestReviewComment>(
+                        owner.root.retrieve()
+                                .asIterator(getApiRoute() + "/comments",
+                                        GHPullRequestReviewComment[].class, pageSize)) {
+                    protected void wrapUp(GHPullRequestReviewComment[] page) {
+                        for (GHPullRequestReviewComment c : page)
+                            c.wrapUp(owner);
+                    }
+                };
+            }
+        };
+    }
+}

--- a/src/main/java/org/kohsuke/github/GHPullRequestReviewComment.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequestReviewComment.java
@@ -25,6 +25,7 @@ package org.kohsuke.github;
 
 import java.io.IOException;
 import java.net.URL;
+import javax.annotation.CheckForNull;
 
 import static org.kohsuke.github.Previews.*;
 
@@ -41,8 +42,8 @@ public class GHPullRequestReviewComment extends GHObject implements Reactable {
     private String body;
     private GHUser user;
     private String path;
-    private int position;
-    private int originalPosition;
+    private int position = -1;
+    private int original_position = -1;
 
     public static GHPullRequestReviewComment draft(String body, String path, int position) {
         GHPullRequestReviewComment result = new GHPullRequestReviewComment();
@@ -82,12 +83,14 @@ public class GHPullRequestReviewComment extends GHObject implements Reactable {
         return path;
     }
 
-    public int getPosition() {
-        return position;
+    @CheckForNull
+    public Integer getPosition() {
+        return position == -1 ? null : position;
     }
 
+    @CheckForNull
     public int getOriginalPosition() {
-        return originalPosition;
+        return original_position == -1 ? null : original_position;
     }
 
     @Override

--- a/src/main/java/org/kohsuke/github/GHPullRequestReviewComment.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequestReviewComment.java
@@ -44,6 +44,8 @@ public class GHPullRequestReviewComment extends GHObject implements Reactable {
     private String path;
     private int position = -1;
     private int original_position = -1;
+    private long in_reply_to_id = -1L;
+
 
     public static GHPullRequestReviewComment draft(String body, String path, int position) {
         GHPullRequestReviewComment result = new GHPullRequestReviewComment();
@@ -89,8 +91,13 @@ public class GHPullRequestReviewComment extends GHObject implements Reactable {
     }
 
     @CheckForNull
-    public int getOriginalPosition() {
+    public Integer getOriginalPosition() {
         return original_position == -1 ? null : original_position;
+    }
+
+    @CheckForNull
+    public Long getInReplyToId() {
+        return in_reply_to_id == -1 ? null : in_reply_to_id;
     }
 
     @Override
@@ -129,7 +136,7 @@ public class GHPullRequestReviewComment extends GHObject implements Reactable {
     public PagedIterable<GHReaction> listReactions() {
         return new PagedIterable<GHReaction>() {
             public PagedIterator<GHReaction> _iterator(int pageSize) {
-                return new PagedIterator<GHReaction>(owner.root.retrieve().withPreview(SQUIRREL_GIRL).asIterator(getApiRoute()+"/reactions", GHReaction[].class, pageSize)) {
+                return new PagedIterator<GHReaction>(owner.root.retrieve().withPreview(SQUIRREL_GIRL).asIterator(getApiRoute() + "/reactions", GHReaction[].class, pageSize)) {
                     @Override
                     protected void wrapUp(GHReaction[] page) {
                         for (GHReaction c : page)

--- a/src/main/java/org/kohsuke/github/GHPullRequestReviewDraft.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequestReviewDraft.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2017, CloudBees, Inc.
+ * Copyright (c) 2011, Eric Maupin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,34 +24,30 @@
 package org.kohsuke.github;
 
 import java.io.IOException;
-import java.util.List;
 
 /**
- * Review to the pull request
+ * Draft of a Pull Request review.
  *
- * @see GHPullRequest#listReviews()
- * @see GHPullRequest#createReview(String, String, GHPullRequestReviewEvent, List)
+ * @see GHPullRequest#newDraftReview(String, String, GHPullRequestReviewComment...)
  */
-public class GHPullRequestReview extends GHPullRequestReviewAbstract {
-    private GHPullRequestReviewState state;
+public class GHPullRequestReviewDraft extends GHPullRequestReviewAbstract {
 
-    @Override
-    public GHPullRequestReviewState getState() {
-        return state;
-    }
-
-    GHPullRequestReview wrapUp(GHPullRequest owner) {
+    GHPullRequestReviewDraft wrapUp(GHPullRequest owner) {
         this.owner = owner;
         return this;
     }
 
-    /**
-     * Dismisses this review.
-     */
-    public void dismiss(String message) throws IOException {
-        new Requester(owner.root).method("PUT")
-                .with("message", message)
-                .to(getApiRoute() + "/dismissals");
-        state = GHPullRequestReviewState.DISMISSED;
+    @Override
+    public GHPullRequestReviewState getState() {
+        return GHPullRequestReviewState.PENDING;
     }
+
+    public void submit(String body, GHPullRequestReviewEvent event) throws IOException {
+        new Requester(owner.root).method("POST")
+                .with("body", body)
+                .with("event", event.action())
+                .to(getApiRoute() + "/events", this);
+        this.body = body;
+    }
+
 }

--- a/src/main/java/org/kohsuke/github/GHPullRequestReviewEvent.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequestReviewEvent.java
@@ -1,0 +1,41 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2011, Eric Maupin
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.kohsuke.github;
+
+public enum GHPullRequestReviewEvent {
+    PENDING(null),
+    APPROVE("APPROVE"),
+    REQUEST_CHANGES("REQUEST_CHANGES"),
+    COMMENT("COMMENT");
+
+    private final String _action;
+
+    GHPullRequestReviewEvent(String action) {
+        _action = action;
+    }
+
+    public String action() {
+        return _action;
+    }
+}

--- a/src/main/java/org/kohsuke/github/GHPullRequestReviewState.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequestReviewState.java
@@ -1,19 +1,9 @@
 package org.kohsuke.github;
 
 public enum GHPullRequestReviewState {
-    PENDING(null),
-    APPROVED("APPROVE"),
-    REQUEST_CHANGES("REQUEST_CHANGES"),
-    COMMENTED("COMMENT"),
-    DISMISSED(null);
-
-    private final String _action;
-
-    GHPullRequestReviewState(String action) {
-        _action = action;
-    }
-
-    public String action() {
-        return _action;
-    }
+    PENDING,
+    APPROVED,
+    CHANGES_REQUESTED,
+    COMMENTED,
+    DISMISSED
 }

--- a/src/main/java/org/kohsuke/github/Requester.java
+++ b/src/main/java/org/kohsuke/github/Requester.java
@@ -134,6 +134,10 @@ class Requester {
         return _with(key, value);
     }
 
+    public Requester with(String key, long value) {
+        return _with(key, value);
+    }
+
     public Requester with(String key, Integer value) {
         if (value!=null)
             _with(key, value);

--- a/src/test/java/org/kohsuke/github/PullRequestTest.java
+++ b/src/test/java/org/kohsuke/github/PullRequestTest.java
@@ -33,7 +33,7 @@ public class PullRequestTest extends AbstractGitHubApiTestBase {
     public void testPullRequestReviews() throws Exception {
         String name = rnd.next();
         GHPullRequest p = getRepository().createPullRequest(name, "stable", "master", "## test");
-        GHPullRequestReview draftReview = p.createReview("Some draft review", null,
+        GHPullRequestReviewDraft draftReview = p.newDraftReview(null, "Some draft review",
                 GHPullRequestReviewComment.draft("Some niggle", "changelog.html", 1)
         );
         assertThat(draftReview.getState(), is(GHPullRequestReviewState.PENDING));
@@ -45,15 +45,15 @@ public class PullRequestTest extends AbstractGitHubApiTestBase {
         assertThat(review.getState(), is(GHPullRequestReviewState.PENDING));
         assertThat(review.getBody(), is("Some draft review"));
         assertThat(review.getCommitId(), notNullValue());
-        review.submit("Some review comment", GHPullRequestReviewEvent.COMMENT);
+        draftReview.submit("Some review comment", GHPullRequestReviewEvent.COMMENT);
         List<GHPullRequestReviewComment> comments = review.listReviewComments().asList();
         assertEquals(1, comments.size());
         GHPullRequestReviewComment comment = comments.get(0);
         assertEquals("Some niggle", comment.getBody());
-        review = p.createReview("Some new review", null,
+        draftReview = p.newDraftReview(null, "Some new review",
                 GHPullRequestReviewComment.draft("Some niggle", "changelog.html", 1)
         );
-        review.delete();
+        draftReview.delete();
     }
 
     @Test

--- a/src/test/java/org/kohsuke/github/PullRequestTest.java
+++ b/src/test/java/org/kohsuke/github/PullRequestTest.java
@@ -45,7 +45,7 @@ public class PullRequestTest extends AbstractGitHubApiTestBase {
         assertThat(review.getState(), is(GHPullRequestReviewState.PENDING));
         assertThat(review.getBody(), is("Some draft review"));
         assertThat(review.getCommitId(), notNullValue());
-        review.submit("Some review comment", GHPullRequestReviewState.COMMENTED);
+        review.submit("Some review comment", GHPullRequestReviewEvent.COMMENT);
         List<GHPullRequestReviewComment> comments = review.listReviewComments().asList();
         assertEquals(1, comments.size());
         GHPullRequestReviewComment comment = comments.get(0);


### PR DESCRIPTION
At SonarSource, we have been using the Github API library for a while.

Unfortunately to implement new features in SonarQube, we hit some limitations.

Support for Pull Request reviews is out of date. Only support for beta has been done, and things changed a bit when the feature got public:

- review state and review event flag actually do not have the same values
- the beta header are now useless
- new review can now be posted in a single API call

Pull Request comment support has some limitations and bugs:

- original_position field of review comments isn't parsed
- a comment's position can actually be null, this indicates an out-of-date comment
- the ability to create a reply hasn't been implemented yet

So we added it to an internal fork and are contributing it back to the community.

Unit test coverage of the changes are far from SonarSource's standard, but we mostly failed at making existing unit tests run (mostly by a lack of the right Github credentials, it seems) so we barely added any new one.

If you have any direction to provide in order to successfully run the existing UTs, we will be happy to provide UT coverage on our new code.

In the mean time, rest assured that the new code has been field tested.

Please let us know if the contribution is acceptable in the shape below. We will be happy to drop our internal fork in favor of the original library when the changes are merged.

Cheers,
  
  