### PR TITLE
[JENKINS-48954] - Add the Jenkins-ClassFilter-Whitelisted manifest entry

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,17 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Jenkins-ClassFilter-Whitelisted>true</Jenkins-ClassFilter-Whitelisted>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
In Jenkins project [JEP-200](https://jenkins.io/blog/2018/01/13/jep-200/) introduces serious changes in class serialization since 2.102. Some Jenkins plugins (e.g. GitHub Pull Request Builder) are affected by the change due to serialization of GitHub API (see [JENKINS-48950](https://issues.jenkins-ci.org/browse/JENKINS-48950)). It is still TBD whether such serialization is desirable, but I am putting this PR here just in case.

Please do not merge for now

@reviewbybees @jglick 
