### PR TITLE
Add GHRepository.getRelease and GHRepository.getReleaseByTagName

### DIFF
--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -310,6 +310,22 @@ public class GHRepository extends GHObject {
     public List<GHRelease> getReleases() throws IOException {
         return listReleases().asList();
     }
+
+    public GHRelease getRelease(long id) throws IOException {
+        try {
+            return root.retrieve().to(getApiTailUrl("releases/" + id), GHRelease.class).wrap(this);
+        } catch (FileNotFoundException e) {
+            return null; // no release for this id
+        }
+    }
+
+    public GHRelease getReleaseByTagName(String tag) throws IOException {
+        try {
+            return root.retrieve().to(getApiTailUrl("releases/tags/" + tag), GHRelease.class).wrap(this);
+        } catch (FileNotFoundException e) {
+            return null; // no release for this tag
+        }
+    }
     
     public GHRelease getLatestRelease() throws IOException {
         try {

--- a/src/test/java/org/kohsuke/github/RepositoryTest.java
+++ b/src/test/java/org/kohsuke/github/RepositoryTest.java
@@ -94,6 +94,36 @@ public class RepositoryTest extends AbstractGitHubApiTestBase {
 		}
 	}
 
+    @Test public void listReleases() throws IOException {
+        PagedIterable<GHRelease> releases = gitHub.getOrganization("github").getRepository("hub").listReleases();
+        assertTrue(releases.iterator().hasNext());
+    }
+
+    @Test
+    public void getReleaseExists() throws IOException {
+        GHRelease release = gitHub.getOrganization("github").getRepository("hub").getRelease(6839710);
+        assertEquals("v2.3.0-pre10", release.getTagName());
+    }
+
+    @Test
+    public void getReleaseDoesNotExist() throws IOException {
+        GHRelease release = gitHub.getOrganization("github").getRepository("hub").getRelease(Long.MAX_VALUE);
+        assertNull(release);
+    }
+
+    @Test
+    public void getReleaseByTagNameExists() throws IOException {
+        GHRelease release = gitHub.getOrganization("github").getRepository("hub").getReleaseByTagName("v2.3.0-pre10");
+        assertNotNull(release);
+        assertEquals("v2.3.0-pre10", release.getTagName());
+    }
+
+    @Test
+    public void getReleaseByTagNameDoesNotExist() throws IOException {
+        GHRelease release = getRepository().getReleaseByTagName("foo-bar-baz");
+        assertNull(release);
+    }
+
     private GHRepository getRepository() throws IOException {
         return gitHub.getOrganization("github-api-test-org").getRepository("jenkins");
     }


### PR DESCRIPTION
These implement the API endpoints for:

- `GET /repos/:owner/:repo/releases/:id`
- `GET /repos/:owner/:repo/releases/tags/:tag`