### PR TITLE
OkHttpConnector: Enforce use of TLSv1.2 to match current Github and Github Enterprise TLS support.

### DIFF
--- a/src/main/java/org/kohsuke/github/extras/OkHttpConnector.java
+++ b/src/main/java/org/kohsuke/github/extras/OkHttpConnector.java
@@ -1,12 +1,24 @@
 package org.kohsuke.github.extras;
 
+import com.squareup.okhttp.ConnectionSpec;
 import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.OkUrlFactory;
+
 import org.kohsuke.github.HttpConnector;
 
 import java.io.IOException;
+
 import java.net.HttpURLConnection;
 import java.net.URL;
+
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
 
 /**
  * {@link HttpConnector} for {@link OkHttpClient}.
@@ -23,10 +35,33 @@ public class OkHttpConnector implements HttpConnector {
     private final OkUrlFactory urlFactory;
 
     public OkHttpConnector(OkUrlFactory urlFactory) {
+        urlFactory.client().setSslSocketFactory(TlsSocketFactory());
+        urlFactory.client().setConnectionSpecs(TlsConnectionSpecs());
         this.urlFactory = urlFactory;
     }
 
     public HttpURLConnection connect(URL url) throws IOException {
         return urlFactory.open(url);
+    }
+
+    /** Returns TLSv1.2 only SSL Socket Factory. */
+    private SSLSocketFactory TlsSocketFactory() {
+        SSLContext sc;
+        try {
+            sc = SSLContext.getInstance("TLSv1.2");
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+        try {
+            sc.init(null, null, null);
+            return sc.getSocketFactory();
+        } catch (KeyManagementException e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    /** Returns connection spec with TLS v1.2 in it */
+    private List<ConnectionSpec> TlsConnectionSpecs() {
+        return Arrays.asList(ConnectionSpec.MODERN_TLS, ConnectionSpec.CLEARTEXT);
     }
 }


### PR DESCRIPTION
On Feb 8, 2018, Github changed their TLS settings to be 1.2 only.
Most recent Jenkins installs are OK as Java 1.8 defaults to TLS 1.2, however some people see intermittent
or continuous failures with connecting to Github in a variety of configurations:

e.g. https://issues.jenkins-ci.org/browse/JENKINS-49761?jql=project%20%3D%20JENKINS%20AND%20component%20%3D%20github-api-plugin 

This PR creates a new TLS v1.2 only SSLContext and attaches its socket factory to the urlFactory passed to OkHttpConnector, which is used by most Github plugins in Jenkins.