### PR TITLE
Add support for previous_filename for file details in PR.

### DIFF
--- a/src/main/java/org/kohsuke/github/GHPullRequestFileDetail.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequestFileDetail.java
@@ -43,6 +43,7 @@ public class GHPullRequestFileDetail {
     String raw_url;
     String contents_url;
     String patch;
+    String previous_filename;
 
     public String getSha() {
         return sha;
@@ -82,5 +83,10 @@ public class GHPullRequestFileDetail {
 
     public String getPatch() {
         return patch;
+    }
+
+    public String getPreviousFilename()
+    {
+        return previous_filename;
     }
 }


### PR DESCRIPTION
In case, when PR contains file that was renamed, file details will look like this:
```
[
  {
    "sha": "0000000000000000000001",
    "filename": "fileName.new",
    "status": "renamed",
    "additions": 1,
    "deletions": 0,
    "changes": 1,
    "blob_url": "https://github.com/...",
    "raw_url": "https://github.com/...",
    "contents_url": "https://api.github.com/repos/...",
    "patch": "...",
    "previous_filename": "fileName.prev"
  }
]
```
So, there is need to support `previous_filename` field to know the previous file name.