### PR TITLE
[fix] fetch labels with HTTP GET method

### DIFF
--- a/src/main/java/org/kohsuke/github/GHPullRequest.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequest.java
@@ -393,7 +393,7 @@ public class GHPullRequest extends GHIssue {
 
     private void fetchIssue() throws IOException {
         if (!fetchedIssueDetails) {
-            new Requester(root).to(getIssuesApiRoute(), this);
+            new Requester(root).method("GET").to(getIssuesApiRoute(), this);
             fetchedIssueDetails = true;
         }
     }


### PR DESCRIPTION
Making this request (by calling `pr.getLabels()`) with POST method changed the updated date of a PR.

Because of that `sort:updated-desc` in the Pull request listing wasn't sorting in the expected order any more.