### PR TITLE
Fix for issue #426. Fix null pointer when deleting refs.

### DIFF
--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -815,7 +815,9 @@ public class GHRepository extends GHObject {
             public PagedIterator<GHRef> _iterator(int pageSize) {
                 return new PagedIterator<GHRef>(root.retrieve().asIterator(url, GHRef[].class, pageSize)) {
                     protected void wrapUp(GHRef[] page) {
-                        // no-op
+                        for(GHRef p: page) {
+                            p.wrap(root);
+                        }
                     }
                 };
             }


### PR DESCRIPTION
Fix for issue #426. This assigns a root to the ref objects, avoiding the null pointer exception.