### PR TITLE
Fix memory leak.

### DIFF
--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -48,6 +48,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.WeakHashMap;
 
 import static java.util.Arrays.*;
 import static org.kohsuke.github.Previews.*;
@@ -79,10 +80,10 @@ public class GHRepository extends GHObject {
     private boolean _private;
     private int forks_count, stargazers_count, watchers_count, size, open_issues_count, subscribers_count;
     private String pushed_at;
-    private Map<Integer,GHMilestone> milestones = new HashMap<Integer, GHMilestone>();
+    private Map<Integer,GHMilestone> milestones = new WeakHashMap<Integer, GHMilestone>();
 
     private String default_branch,language;
-    private Map<String,GHCommit> commits = new HashMap<String, GHCommit>();
+    private Map<String,GHCommit> commits = new WeakHashMap<String, GHCommit>();
 
     @SkipFromToString
     private GHRepoPermission permissions;


### PR DESCRIPTION
While repository object is active and code requests commits they are stored in Map.
GHCommit.files contains huge String[]/char[]  amount of data.
The same could be applied to Milestones.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kohsuke/github-api/468)
<!-- Reviewable:end -->
