### PR TITLE
Added archived attribute in GHRepository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kohsuke</groupId>
     <artifactId>pom</artifactId>
-    <version>17</version>
+    <version>20</version>
   </parent>
 
   <artifactId>github-api</artifactId>
@@ -36,6 +36,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.22.1</version>
         <configuration>
           <rerunFailingTestsCount>2</rerunFailingTestsCount>
         </configuration>

--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -74,7 +74,7 @@ public class GHRepository extends GHObject {
 
     private String git_url, ssh_url, clone_url, svn_url, mirror_url;
     private GHUser owner;   // not fully populated. beware.
-    private boolean has_issues, has_wiki, fork, has_downloads, has_pages;
+    private boolean has_issues, has_wiki, fork, has_downloads, has_pages, archived;
     @JsonProperty("private")
     private boolean _private;
     private int forks_count, stargazers_count, watchers_count, size, open_issues_count, subscribers_count;
@@ -391,6 +391,10 @@ public class GHRepository extends GHObject {
 
     public boolean isFork() {
         return fork;
+    }
+
+    public boolean isArchived() {
+        return archived;
     }
 
     /**


### PR DESCRIPTION
- `archived` attribute was missed and can be interesting in many cases
- Updated parent POM from [17 to 20](https://github.com/kohsuke/pom/compare/pom-17...pom-20)
- Addressed a Apache Maven warning

```
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.kohsuke:github-api:jar:1.95-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ line 37, column 15
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
```

@kohsuke, could you take a look? Thanks.