### PR TITLE
Provide more exception details

### DIFF
--- a/src/main/java/org/kohsuke/github/Requester.java
+++ b/src/main/java/org/kohsuke/github/Requester.java
@@ -526,7 +526,7 @@ class Requester {
                     }
                 }
             } catch (IOException e) {
-                throw new GHException("Failed to retrieve "+url);
+                throw new GHException("Failed to retrieve " + url, e);
             }
         }
 


### PR DESCRIPTION
For now if invalid credentials used to search repositories, github-api throws following exception

    Exception in thread "main" org.kohsuke.github.GHException: Failed to retrieve https://api.github.com/search/repositories?q=vk+language%3Ajava+created%3A2015-11-26..2016-11-26
	at org.kohsuke.github.Requester$PagingIterator.fetch(Requester.java:529)
	at org.kohsuke.github.Requester$PagingIterator.hasNext(Requester.java:494)
	at org.kohsuke.github.PagedSearchIterable$1.hasNext(PagedSearchIterable.java:55)
	at org.kohsuke.github.PagedIterator.fetch(PagedIterator.java:44)
	at org.kohsuke.github.PagedIterator.hasNext(PagedIterator.java:32)

There is no mentions about credentials at all. Better to propagate exception to user to be able to deal with it.