### PR TITLE
remove system.out from listOrgs

### DIFF
--- a/src/main/java/org/kohsuke/github/GitHub.java
+++ b/src/main/java/org/kohsuke/github/GitHub.java
@@ -452,7 +452,6 @@ public class GitHub {
         return new PagedIterable<GHOrganization>() {
             @Override
             public PagedIterator<GHOrganization> _iterator(int pageSize) {
-                System.out.println("page size: " + pageSize);
                 return new PagedIterator<GHOrganization>(retrieve().with("since",since)
                         .asIterator("/organizations", GHOrganization[].class, pageSize)) {
                     @Override


### PR DESCRIPTION
Removal of a `System.out` usage printing the pageSize on each iteration.