### PR TITLE
proposed fix for GHTeam.add in issue #489

### DIFF
--- a/src/main/java/org/kohsuke/github/GHTeam.java
+++ b/src/main/java/org/kohsuke/github/GHTeam.java
@@ -23,11 +23,11 @@ public class GHTeam {
         /**
          * A normal member of the team
          */
-        MEMBER,
+        member,
         /**
          * Able to add/remove other team members, promote other team members to team maintainer, and edit the team's name and description.
          */
-        MAINTAINER
+        maintainer
     }
 
     /*package*/ GHTeam wrapUp(GHOrganization owner) {


### PR DESCRIPTION
This breaks library reverse compatibility for code that uses original GHTeam.Role.MEMBER and GHTeam.Role.MAINTAINER. Alternative is worse since reverse compatibility can only be preserved at expense of valueOf and using toString instead of name