### PR TITLE
Create PR from original repo to private org fork

### DIFF
--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -758,10 +758,36 @@ public class GHRepository extends GHObject {
      *      of a pull request.
      */
     public GHPullRequest createPullRequest(String title, String head, String base, String body) throws IOException {
+        return createPullRequest(title, head, base, body, true);
+    }
+
+    /**
+     * Creates a new pull request. Maintainer's permissions aware.
+     *
+     * @param title
+     *      Required. The title of the pull request.
+     * @param head
+     *      Required. The name of the branch where your changes are implemented.
+     *      For cross-repository pull requests in the same network,
+     *      namespace head with a user like this: username:branch.
+     * @param base
+     *      Required. The name of the branch you want your changes pulled into.
+     *      This should be an existing branch on the current repository.
+     * @param body
+     *      The contents of the pull request. This is the markdown description
+     *      of a pull request.
+     * @param maintainerCanModify
+     *      Indicates whether maintainers can modify the pull request.
+     */
+    public GHPullRequest createPullRequest(String title, String head, String base, String body,
+            boolean maintainerCanModify) throws IOException {
         return new Requester(root).with("title",title)
                 .with("head",head)
                 .with("base",base)
-                .with("body",body).to(getApiTailUrl("pulls"),GHPullRequest.class).wrapUp(this);
+                .with("body",body)
+                .with("maintainer_can_modify", maintainerCanModify)
+                .to(getApiTailUrl("pulls"),GHPullRequest.class)
+                .wrapUp(this);
     }
 
     /**


### PR DESCRIPTION
Use case: when fork is done into private organization then the original repo maintainer can't have any access there hence this field has to be set to `false` explicitly.

Added parameter: `maintainerCanModify` to `GHRepository.createPullRequest` method. 

- Indicates whether maintainers can modify the pull request

Original method is kept for backward compatibility defaulting the parameter to `true`. 